### PR TITLE
Cpp11compat

### DIFF
--- a/synthesis/MeasurementComponents/AWProjectFT.h
+++ b/synthesis/MeasurementComponents/AWProjectFT.h
@@ -166,7 +166,7 @@ namespace casa { //# NAMESPACE CASA - BEGIN
     // Assignment operator
     AWProjectFT &operator=(const AWProjectFT &other);
     
-    ~AWProjectFT();
+    ~AWProjectFT() CASAREST_NOEXCEPT;
     
     //   void setEPJones(EPJones* ep_j) {epJ = ep_j;}
     void setEPJones(SolvableVisJones* ep_j) {epJ_p = ep_j;}

--- a/synthesis/MeasurementComponents/FTMachine.h
+++ b/synthesis/MeasurementComponents/FTMachine.h
@@ -45,6 +45,12 @@
 #include <synthesis/MeasurementComponents/CFCache.h>
 #include <synthesis/MeasurementComponents/ConvolutionFunction.h>
 
+#if __cplusplus > 199711L
+#define CASAREST_NOEXCEPT noexcept
+#else
+#define CASAREST_NOEXCEPT
+#endif
+
 namespace casa { //# NAMESPACE CASA - BEGIN
 
 class VisSet;

--- a/synthesis/MeasurementComponents/nPBWProjectFT.h
+++ b/synthesis/MeasurementComponents/nPBWProjectFT.h
@@ -159,12 +159,6 @@ namespace casa { //# NAMESPACE CASA - BEGIN
     // Assignment operator
     nPBWProjectFT &operator=(const nPBWProjectFT &other);
 
-#if __cplusplus > 199711L
-#define CASAREST_NOEXCEPT noexcept
-#else
-#define CASAREST_NOEXCEPT
-#endif
-
     ~nPBWProjectFT() CASAREST_NOEXCEPT;
     
     //   void setEPJones(EPJones* ep_j) {epJ = ep_j;}

--- a/synthesis/MeasurementComponents/nPBWProjectFT.h
+++ b/synthesis/MeasurementComponents/nPBWProjectFT.h
@@ -158,8 +158,14 @@ namespace casa { //# NAMESPACE CASA - BEGIN
     
     // Assignment operator
     nPBWProjectFT &operator=(const nPBWProjectFT &other);
-    
-    ~nPBWProjectFT();
+
+#if __cplusplus > 199711L
+#define CASAREST_NOEXCEPT noexcept
+#else
+#define CASAREST_NOEXCEPT
+#endif
+
+    ~nPBWProjectFT() CASAREST_NOEXCEPT;
     
     //   void setEPJones(EPJones* ep_j) {epJ = ep_j;}
     void setEPJones(SolvableVisJones* ep_j) {epJ = ep_j;}


### PR DESCRIPTION
When compiling with `-std=c++11` two destructors give an error, because the compiler thinks they can throw an AipsError. Marking them explicitly with `noexcept` makes the error go away. The word `noexcept` does not exist in C++98, so it's implemented through a define.