### PR TITLE
Fix builds without HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if(HDF5_FOUND)
 else(HDF5_FOUND)
     message(STATUS "  HDF5 not used")
     set(HDF5_LIBRARIES )
+    set(HDF5_INCLUDE_DIRS )
 endif(HDF5_FOUND)
 
 # options and defaults


### PR DESCRIPTION
Let's see if this fixes the Travis build, which doesn't use HDF5.