### PR TITLE
Hotfix/cmake components

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ make
 make install
 ```
 
+There are 4 components in the casarest package and you may not need all them. The four targets are: casa_components, casa_msvis, casa_calibration and casa_synthesis. You can make them individuallay by:
+```
+mkdir build
+cd build
+cmake ..
+make <choice of target>
+cmake -DCOMPONENT=<choice of target>  -P cmake_install.cmake 
+```
+Which will build and install only your choice of target.
+
+
 ## Ubuntu 14.04 packages
 
 If you run Ubuntu 14.04 you can use precompiled binary packages

--- a/calibration/CMakeLists.txt
+++ b/calibration/CMakeLists.txt
@@ -67,14 +67,14 @@ set(calibration_LIB_SRCS
 
 
 add_library(casa_calibration ${calibration_LIB_SRCS})
-install(TARGETS casa_calibration DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENTS calibration)
+install(TARGETS casa_calibration DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT calibration)
 target_link_libraries(casa_calibration casa_msvis ${OTHER_LIBRARIES})
 set(CALIBRATION_LIBRARIES casa_calibration casa_msvis ${OTHER_LIBRARIES})
 
 
 install (FILES
 CalTables.h
-DESTINATION include/casarest/calibration
+DESTINATION include/casarest/calibration COMPONENT calibration
 )
 
 install (FILES
@@ -154,5 +154,5 @@ CalTables/CalMainColumns2.tcc
 CalTables/CalSet.tcc
 CalTables/ROCalMainColumns2.tcc
 CalTables/SolvableCalSetMCol.tcc
-DESTINATION include/casarest/calibration/CalTables
+DESTINATION include/casarest/calibration/CalTables COMPONENT calibration
 )

--- a/calibration/CMakeLists.txt
+++ b/calibration/CMakeLists.txt
@@ -67,7 +67,7 @@ set(calibration_LIB_SRCS
 
 
 add_library(casa_calibration ${calibration_LIB_SRCS})
-install(TARGETS casa_calibration DESTINATION ${LIBRARY_INSTALL_DIR})
+install(TARGETS casa_calibration DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENTS calibration)
 target_link_libraries(casa_calibration casa_msvis ${OTHER_LIBRARIES})
 set(CALIBRATION_LIBRARIES casa_calibration casa_msvis ${OTHER_LIBRARIES})
 

--- a/calibration/CMakeLists.txt
+++ b/calibration/CMakeLists.txt
@@ -67,14 +67,14 @@ set(calibration_LIB_SRCS
 
 
 add_library(casa_calibration ${calibration_LIB_SRCS})
-install(TARGETS casa_calibration DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT calibration)
+install(TARGETS casa_calibration DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT casa_calibration)
 target_link_libraries(casa_calibration casa_msvis ${OTHER_LIBRARIES})
 set(CALIBRATION_LIBRARIES casa_calibration casa_msvis ${OTHER_LIBRARIES})
 
 
 install (FILES
 CalTables.h
-DESTINATION include/casarest/calibration COMPONENT calibration
+DESTINATION include/casarest/calibration COMPONENT casa_calibration
 )
 
 install (FILES
@@ -154,5 +154,5 @@ CalTables/CalMainColumns2.tcc
 CalTables/CalSet.tcc
 CalTables/ROCalMainColumns2.tcc
 CalTables/SolvableCalSetMCol.tcc
-DESTINATION include/casarest/calibration/CalTables COMPONENT calibration
+DESTINATION include/casarest/calibration/CalTables COMPONENT casa_calibration
 )

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -44,7 +44,7 @@ ComponentModels/TabularSpectrum.cc
 ComponentModels/ComponentType2.cc
 )
 
-install(TARGETS casa_components DESTINATION ${LIBRARY_INSTALL_DIR})
+install(TARGETS casa_components DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT components)
 target_link_libraries(casa_components ${OTHER_LIBRARIES} ${LIB_EXTRA_COMPONENTS})
 set(COMPONENTS_LIBRARIES casa_components ${OTHER_LIBRARIES} ${LIB_EXTRA_COMPONENTS})
 

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -44,7 +44,7 @@ ComponentModels/TabularSpectrum.cc
 ComponentModels/ComponentType2.cc
 )
 
-install(TARGETS casa_components DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT components)
+install(TARGETS casa_components DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT casa_components)
 target_link_libraries(casa_components ${OTHER_LIBRARIES} ${LIB_EXTRA_COMPONENTS})
 set(COMPONENTS_LIBRARIES casa_components ${OTHER_LIBRARIES} ${LIB_EXTRA_COMPONENTS})
 
@@ -76,7 +76,7 @@ ComponentModels/FluxStdsQS2.h
 ComponentModels/FluxStdSrcs.h
 ComponentModels/Flux.h
 ComponentModels/Flux.tcc
-DESTINATION include/casarest/components/ComponentModels COMPONENT components
+DESTINATION include/casarest/components/ComponentModels COMPONENT casa_components
 )
 
 install (FILES
@@ -98,13 +98,13 @@ SpectralComponents/SpectralFit.h
 SpectralComponents/SpectralFit2.tcc
 SpectralComponents/SpectralList.h
 SpectralComponents/SpectralList2.tcc
-DESTINATION include/casarest/components/SpectralComponents COMPONENT components
+DESTINATION include/casarest/components/SpectralComponents COMPONENT casa_components
 )
 
 install (FILES
 ComponentModels.h
 SpectralComponents.h
-DESTINATION include/casarest/components COMPONENT components
+DESTINATION include/casarest/components COMPONENT casa_components
 )
 
 if (BUILD_TESTING)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -76,7 +76,7 @@ ComponentModels/FluxStdsQS2.h
 ComponentModels/FluxStdSrcs.h
 ComponentModels/Flux.h
 ComponentModels/Flux.tcc
-DESTINATION include/casarest/components/ComponentModels
+DESTINATION include/casarest/components/ComponentModels COMPONENT components
 )
 
 install (FILES
@@ -98,13 +98,13 @@ SpectralComponents/SpectralFit.h
 SpectralComponents/SpectralFit2.tcc
 SpectralComponents/SpectralList.h
 SpectralComponents/SpectralList2.tcc
-DESTINATION include/casarest/components/SpectralComponents
+DESTINATION include/casarest/components/SpectralComponents COMPONENT components
 )
 
 install (FILES
 ComponentModels.h
 SpectralComponents.h
-DESTINATION include/casarest/components
+DESTINATION include/casarest/components COMPONENT components
 )
 
 if (BUILD_TESTING)

--- a/msvis/CMakeLists.txt
+++ b/msvis/CMakeLists.txt
@@ -30,14 +30,14 @@ set(msvis_LIB_SRCS
 
 
 add_library(casa_msvis ${msvis_LIB_SRCS})
-install(TARGETS casa_msvis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT msvis)
+install(TARGETS casa_msvis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT casa_msvis)
 target_link_libraries(casa_msvis ${OTHER_LIBRARIES})
 set(MSVIS_LIBRARIES casa_msvis ${OTHER_LIBRARIES})
 
 
 install (FILES
 MSVis.h
-DESTINATION include/casarest/msvis COMPONENT msvis
+DESTINATION include/casarest/msvis COMPONENT casa_msvis
 )
 
 install (FILES
@@ -75,5 +75,5 @@ MSVis/MSMoments.tcc
 MSVis/SubMS.tcc
 MSVis/VisBuffer.tcc
 MSVis/VisibilityIterator.tcc
-DESTINATION include/casarest/msvis/MSVis COMPONENT msvis
+DESTINATION include/casarest/msvis/MSVis COMPONENT casa_msvis
 )

--- a/msvis/CMakeLists.txt
+++ b/msvis/CMakeLists.txt
@@ -30,7 +30,7 @@ set(msvis_LIB_SRCS
 
 
 add_library(casa_msvis ${msvis_LIB_SRCS})
-install(TARGETS casa_msvis DESTINATION ${LIBRARY_INSTALL_DIR})
+install(TARGETS casa_msvis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENTS msvis)
 target_link_libraries(casa_msvis ${OTHER_LIBRARIES})
 set(MSVIS_LIBRARIES casa_msvis ${OTHER_LIBRARIES})
 

--- a/msvis/CMakeLists.txt
+++ b/msvis/CMakeLists.txt
@@ -30,14 +30,14 @@ set(msvis_LIB_SRCS
 
 
 add_library(casa_msvis ${msvis_LIB_SRCS})
-install(TARGETS casa_msvis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENTS msvis)
+install(TARGETS casa_msvis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT msvis)
 target_link_libraries(casa_msvis ${OTHER_LIBRARIES})
 set(MSVIS_LIBRARIES casa_msvis ${OTHER_LIBRARIES})
 
 
 install (FILES
 MSVis.h
-DESTINATION include/casarest/msvis
+DESTINATION include/casarest/msvis COMPONENT msvis
 )
 
 install (FILES
@@ -75,5 +75,5 @@ MSVis/MSMoments.tcc
 MSVis/SubMS.tcc
 MSVis/VisBuffer.tcc
 MSVis/VisibilityIterator.tcc
-DESTINATION include/casarest/msvis/MSVis
+DESTINATION include/casarest/msvis/MSVis COMPONENT msvis
 )

--- a/synthesis/CMakeLists.txt
+++ b/synthesis/CMakeLists.txt
@@ -162,14 +162,14 @@ set(synthesis_PROGRAMS
 
 
 add_library(casa_synthesis ${synthesis_LIB_SRCS})
-install(TARGETS casa_synthesis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT synthesis)
+install(TARGETS casa_synthesis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT casa_synthesis)
 target_link_libraries(casa_synthesis casa_components casa_calibration casa_msvis ${OTHER_LIBRARIES} ${LIB_EXTRA_SYNTHESIS})
 set(SYNTHESIS_LIBRARIES casa_synthesis casa_components casa_calibration casa_msvis ${OTHER_LIBRARIES} ${LIB_EXTRA_SYNTHESIS})
 
 foreach(prog ${synthesis_PROGRAMS})
     add_executable(${prog} apps/${prog}.cc)
     target_link_libraries(${prog} ${SYNTHESIS_LIBRARIES})
-    install(TARGETS ${prog} DESTINATION bin COMPONENT synthesis)
+    install(TARGETS ${prog} DESTINATION bin COMPONENT casa_synthesis)
 endforeach(prog ${synthesis_PROGRAMS})
 
 
@@ -178,7 +178,7 @@ DataSampling.h
 MeasurementComponents.h
 MeasurementEquations.h
 Parallel.h
-DESTINATION include/casarest/synthesis COMPONENT synthesis
+DESTINATION include/casarest/synthesis COMPONENT casa_synthesis
 )
 
 install (FILES
@@ -187,12 +187,12 @@ DataSampling/ImageDataSampling.h
 DataSampling/PixonProcessor.h
 DataSampling/SDDataSampling.h
 DataSampling/SynDataSampling.h
-DESTINATION include/casarest/synthesis/DataSampling COMPONENT synthesis
+DESTINATION include/casarest/synthesis/DataSampling COMPONENT casa_synthesis
 )
 
 install (FILES
 IDL/IDL.h
-DESTINATION include/casarest/synthesis/IDL COMPONENT synthesis
+DESTINATION include/casarest/synthesis/IDL COMPONENT casa_synthesis
 )
 
 install (FILES
@@ -317,7 +317,7 @@ MeasurementComponents/nPBWProjectFT.h
 MeasurementComponents/rGridFT.h
 MeasurementComponents/ImageSkyModel.tcc
 MeasurementComponents/AWProjectFT.FORTRANSTUFF.INC
-DESTINATION include/casarest/synthesis/MeasurementComponents COMPONENT synthesis
+DESTINATION include/casarest/synthesis/MeasurementComponents COMPONENT casa_synthesis
 )
 
 install (FILES
@@ -366,7 +366,7 @@ MeasurementEquations/MaskedArrayModel.tcc
 MeasurementEquations/MaskedHogbomCleanModel.tcc
 MeasurementEquations/ResidualEquation.tcc
 MeasurementEquations/StokesUtil.tcc
-DESTINATION include/casarest/synthesis/MeasurementEquations COMPONENT synthesis
+DESTINATION include/casarest/synthesis/MeasurementEquations COMPONENT casa_synthesis
 )
 
 install (FILES
@@ -375,13 +375,13 @@ Parallel/Applicator.h
 Parallel/MPIError.h
 Parallel/PTransport.h
 Parallel/PabloIO.h
-DESTINATION include/casarest/synthesis/Parallel COMPONENT synthesis
+DESTINATION include/casarest/synthesis/Parallel COMPONENT casa_synthesis
 )
 
 install (FILES
 Utilities/FixVis.h
 Utilities/ThreadCoordinator.h
-DESTINATION include/casarest/synthesis/Utilities COMPONENT synthesis
+DESTINATION include/casarest/synthesis/Utilities COMPONENT casa_synthesis
 )
 
 
@@ -389,6 +389,6 @@ install (FILES
 Images/ImageFFT.h
 Images/ImageMetaData.h
 Images/ImagePolarimetry.h
-DESTINATION include/casarest/synthesis/Images COMPONENT synthesis
+DESTINATION include/casarest/synthesis/Images COMPONENT casa_synthesis
 )
 

--- a/synthesis/CMakeLists.txt
+++ b/synthesis/CMakeLists.txt
@@ -162,7 +162,7 @@ set(synthesis_PROGRAMS
 
 
 add_library(casa_synthesis ${synthesis_LIB_SRCS})
-install(TARGETS casa_synthesis DESTINATION ${LIBRARY_INSTALL_DIR})
+install(TARGETS casa_synthesis DESTINATION ${LIBRARY_INSTALL_DIR} synthesis)
 target_link_libraries(casa_synthesis casa_components casa_calibration casa_msvis ${OTHER_LIBRARIES} ${LIB_EXTRA_SYNTHESIS})
 set(SYNTHESIS_LIBRARIES casa_synthesis casa_components casa_calibration casa_msvis ${OTHER_LIBRARIES} ${LIB_EXTRA_SYNTHESIS})
 

--- a/synthesis/CMakeLists.txt
+++ b/synthesis/CMakeLists.txt
@@ -162,14 +162,14 @@ set(synthesis_PROGRAMS
 
 
 add_library(casa_synthesis ${synthesis_LIB_SRCS})
-install(TARGETS casa_synthesis DESTINATION ${LIBRARY_INSTALL_DIR} synthesis)
+install(TARGETS casa_synthesis DESTINATION ${LIBRARY_INSTALL_DIR} COMPONENT synthesis)
 target_link_libraries(casa_synthesis casa_components casa_calibration casa_msvis ${OTHER_LIBRARIES} ${LIB_EXTRA_SYNTHESIS})
 set(SYNTHESIS_LIBRARIES casa_synthesis casa_components casa_calibration casa_msvis ${OTHER_LIBRARIES} ${LIB_EXTRA_SYNTHESIS})
 
 foreach(prog ${synthesis_PROGRAMS})
     add_executable(${prog} apps/${prog}.cc)
     target_link_libraries(${prog} ${SYNTHESIS_LIBRARIES})
-    install(TARGETS ${prog} DESTINATION bin)
+    install(TARGETS ${prog} DESTINATION bin COMPONENT synthesis)
 endforeach(prog ${synthesis_PROGRAMS})
 
 
@@ -178,7 +178,7 @@ DataSampling.h
 MeasurementComponents.h
 MeasurementEquations.h
 Parallel.h
-DESTINATION include/casarest/synthesis
+DESTINATION include/casarest/synthesis COMPONENT synthesis
 )
 
 install (FILES
@@ -187,12 +187,12 @@ DataSampling/ImageDataSampling.h
 DataSampling/PixonProcessor.h
 DataSampling/SDDataSampling.h
 DataSampling/SynDataSampling.h
-DESTINATION include/casarest/synthesis/DataSampling
+DESTINATION include/casarest/synthesis/DataSampling COMPONENT synthesis
 )
 
 install (FILES
 IDL/IDL.h
-DESTINATION include/casarest/synthesis/IDL
+DESTINATION include/casarest/synthesis/IDL COMPONENT synthesis
 )
 
 install (FILES
@@ -317,7 +317,7 @@ MeasurementComponents/nPBWProjectFT.h
 MeasurementComponents/rGridFT.h
 MeasurementComponents/ImageSkyModel.tcc
 MeasurementComponents/AWProjectFT.FORTRANSTUFF.INC
-DESTINATION include/casarest/synthesis/MeasurementComponents
+DESTINATION include/casarest/synthesis/MeasurementComponents COMPONENT synthesis
 )
 
 install (FILES
@@ -366,7 +366,7 @@ MeasurementEquations/MaskedArrayModel.tcc
 MeasurementEquations/MaskedHogbomCleanModel.tcc
 MeasurementEquations/ResidualEquation.tcc
 MeasurementEquations/StokesUtil.tcc
-DESTINATION include/casarest/synthesis/MeasurementEquations
+DESTINATION include/casarest/synthesis/MeasurementEquations COMPONENT synthesis
 )
 
 install (FILES
@@ -375,13 +375,13 @@ Parallel/Applicator.h
 Parallel/MPIError.h
 Parallel/PTransport.h
 Parallel/PabloIO.h
-DESTINATION include/casarest/synthesis/Parallel
+DESTINATION include/casarest/synthesis/Parallel COMPONENT synthesis
 )
 
 install (FILES
 Utilities/FixVis.h
 Utilities/ThreadCoordinator.h
-DESTINATION include/casarest/synthesis/Utilities
+DESTINATION include/casarest/synthesis/Utilities COMPONENT synthesis
 )
 
 
@@ -389,6 +389,6 @@ install (FILES
 Images/ImageFFT.h
 Images/ImageMetaData.h
 Images/ImagePolarimetry.h
-DESTINATION include/casarest/synthesis/Images
+DESTINATION include/casarest/synthesis/Images COMPONENT synthesis
 )
 


### PR DESCRIPTION
This is a simple addition to the CMakeLists.txt files and the README.md that allows the users to compile and install the targets separately. A simple temporary fix until the msvis compatibilities with casacore can be resolved