### PR TITLE
Minimal changes to make casarest compatible with cc 311

### DIFF
--- a/.travis/clang.docker
+++ b/.travis/clang.docker
@@ -1,19 +1,50 @@
-FROM kernsuite/base:dev
+FROM kernsuite/base:5
 RUN docker-apt-install \
+    build-essential \
     clang \
     cmake \
-    casacore-dev \
-    casacore-tools \
-    casacore-data \
     libhdf5-dev \
-    libboost-dev \
+    libboost-all-dev \
     wcslib-dev \
     libcfitsio-dev \
     libboost-system-dev \
     libboost-thread-dev \
     libblas-dev \
     liblapack-dev \
-    gfortran
+    libncurses5-dev \
+    libsofa1-dev \
+    bison \
+    libbison-dev \
+    flex \
+    libreadline6-dev \
+    gfortran \
+    python-dev \
+    python-numpy \
+    wget
+
+#####################################################################
+## BUILD CASACORE FROM SOURCE
+#####################################################################
+RUN mkdir /src
+WORKDIR /src
+RUN wget https://github.com/casacore/casacore/archive/v3.1.1.tar.gz
+RUN tar xvf v3.1.1.tar.gz
+RUN mkdir casacore-3.1.1/build
+WORKDIR /src/casacore-3.1.1/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_DEPRECATED=ON ../
+RUN make -j 4
+RUN make install
+RUN ldconfig
+#RUN pip install -U --user --force-reinstall --install-option="--prefix=/usr"  pip setuptools wheel
+
+#####################################################################
+## Get CASACORE ephem data
+#####################################################################
+RUN mkdir -p /usr/share/casacore/data/
+WORKDIR /usr/share/casacore/data/
+RUN docker-apt-install rsync
+RUN rsync -avz rsync://casa-rsync.nrao.edu/casa-data .
+
 ADD . /code
 RUN mkdir /code/build
 WORKDIR /code/build

--- a/.travis/gcc.docker
+++ b/.travis/gcc.docker
@@ -1,23 +1,53 @@
-FROM kernsuite/base:dev
+FROM kernsuite/base:5
 RUN docker-apt-install \
     build-essential \
     cmake \
-    casacore-dev \
-    casacore-data \
-    casacore-tools \
     libhdf5-dev \
-    libboost-dev \
+    libboost-all-dev \
     wcslib-dev \
     libcfitsio-dev \
     libboost-system-dev \
     libboost-thread-dev \
     libblas-dev \
     liblapack-dev \
-    gfortran
+    libncurses5-dev \
+    libsofa1-dev \
+    bison \
+    libbison-dev \
+    flex \
+    libreadline6-dev \
+    gfortran \
+    python-dev \
+    python-numpy \
+    wget
+
+#####################################################################
+## BUILD CASACORE FROM SOURCE
+#####################################################################
+RUN mkdir /src
+WORKDIR /src
+RUN wget https://github.com/casacore/casacore/archive/v3.1.1.tar.gz
+RUN tar xvf v3.1.1.tar.gz
+RUN mkdir casacore-3.1.1/build
+WORKDIR /src/casacore-3.1.1/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_DEPRECATED=ON ../
+RUN make -j 4
+RUN make install
+RUN ldconfig
+#RUN pip install -U --user --force-reinstall --install-option="--prefix=/usr"  pip setuptools wheel
+
+#####################################################################
+## Get CASACORE ephem data
+#####################################################################
+RUN mkdir -p /usr/share/casacore/data/
+WORKDIR /usr/share/casacore/data/
+RUN docker-apt-install rsync
+RUN rsync -avz rsync://casa-rsync.nrao.edu/casa-data .
+
 ADD . /code
 RUN mkdir /code/build
 WORKDIR /code/build
 RUN cmake .. \
-      -DBUILD_TESTING=ON
-RUN make -j4 
+      -DBUILD_TESTING=OFF
+RUN make
 RUN make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 2.8)
 # project version
 set( ${PROJECT_NAME}_MAJOR_VERSION 1 )
 set( ${PROJECT_NAME}_MINOR_VERSION 5 )
-set( ${PROJECT_NAME}_PATCH_LEVEL 0 )
+set( ${PROJECT_NAME}_PATCH_LEVEL 1 )
 
 if (UseCasaNamespace)
     add_definitions (-DUseCasaNamespace)
@@ -55,6 +55,7 @@ include (CTest)
 # Determine which external packages to use.
 # dependencies
 find_package(CasaCore REQUIRED)
+add_definitions(-DAIPS_USE_DEPRECATED) # until such time that we can fully port this package
 find_package(CFITSIO 3.030 REQUIRED) # Should pad to three decimal digits
 find_package(WCSLIB 4.7 REQUIRED)    # needed for CASA
 find_package(BLAS REQUIRED)

--- a/msvis/MSVis/SubMS.cc
+++ b/msvis/MSVis/SubMS.cc
@@ -427,14 +427,14 @@ Bool SubMS::getCorrMaps(MSSelection& mssel, const MeasurementSet& ms,
     
   if(areSelecting){
     // Get the corr indices as an ordered map
-    OrderedMap<Int, Vector<Vector<Int> > > corrmap(mssel.getCorrMap(&ms));
+    std::map<Int, Vector<Vector<Int> > > corrmap(mssel.getCorrMap(&ms));
 
     // Iterate over the ordered map to fill the vector maps
-    ConstMapIter<Int, Vector<Vector<Int> > > mi(corrmap);
-    for(mi.toStart(); !mi.atEnd(); ++mi){
-      Int pol = mi.getKey();
+    std::map<Int, Vector<Vector<Int> > >::iterator mi;
+    for(mi = corrmap.begin(); mi != corrmap.end(); ++mi){
+      Int pol = mi->first;
 
-      outToIn[pol] = mi.getVal()[0];
+      outToIn[pol] = mi->second[0];
     }
   }
   else{	// Make outToIn an identity map.

--- a/msvis/MSVis/VisImagingWeight.h
+++ b/msvis/MSVis/VisImagingWeight.h
@@ -28,6 +28,7 @@
 
 #ifndef VISIMAGINGWEIGHT_H
 #define VISIMAGINGWEIGHT_H
+#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/aips.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/Quanta/Quantum.h>


### PR DESCRIPTION
@schiebel can you please review. I'm not going to undertake a full port of casarest to the stl containers at this point, but these are the bare minimum changes needed to port this code to casacore v 3.1.1 and therefore get a working copy of lwimager, etc for KERN 6.