### PR TITLE
Remove support for CHANNEL_SELECTION keyword

### DIFF
--- a/msvis/MSVis/SubMS.cc
+++ b/msvis/MSVis/SubMS.cc
@@ -791,24 +791,6 @@ Bool SubMS::getCorrMaps(MSSelection& mssel, const MeasurementSet& ms,
       //Detaching the selected part
       ms_p=MeasurementSet();
       
-      //
-      // If all columns are in the new MS, set the CHANNEL_SELECTION
-      // keyword for the MODEL_DATA column.  This is apparently used
-      // in at least imager to decide if MODEL_DATA and CORRECTED_DATA
-      // columns should be initialized or not.
-      //
-      if (isAllColumns(colNamesTok))
-        {
-          MSSpWindowColumns msSpW(msOut_p.spectralWindow());
-          Int nSpw=msOut_p.spectralWindow().nrow();
-          if(nSpw==0) nSpw=1;
-          Matrix<Int> selection(2,nSpw);
-          selection.row(0)=0; //start
-          selection.row(1)=msSpW.numChan().getColumn();
-          ArrayColumn<Complex> mcd(msOut_p,MS::columnName(MS::MODEL_DATA));
-          mcd.rwKeywordSet().define("CHANNEL_SELECTION",selection);
-        }
-
       delete outpointer;
       return True;
     }

--- a/msvis/MSVis/VisSet.cc
+++ b/msvis/MSVis/VisSet.cc
@@ -88,17 +88,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     }
 
     Bool init=True;
-    if (ms.tableDesc().isColumn("MODEL_DATA")) {
-      TableColumn col(ms,"MODEL_DATA");
-      if (col.keywordSet().isDefined("CHANNEL_SELECTION")) {
-	Matrix<Int> storedSelection;
-	col.keywordSet().get("CHANNEL_SELECTION",storedSelection);
-	if (selection_p.shape()==storedSelection.shape() && 
-	    allEQ(selection_p,storedSelection)) {
-	  init=False;
-	} 
-      }
-    }
     
     // Add scratch columns
     if (init) {

--- a/msvis/MSVis/VisibilityIterator.cc
+++ b/msvis/MSVis/VisibilityIterator.cc
@@ -550,7 +550,7 @@ void ROVisibilityIterator::setState()
 	numChanGroup_p[spw] == 0) {
       // no selection set yet, set default = all
       // for a reference MS this will normally be set appropriately in VisSet
-      selectChannel(1,msIter_p.startChan(),nChan_p);
+      selectChannel(1,0,nChan_p);
     }
     channelGroupSize_p=chanWidth_p[spw];
     curNumChanGroup_p=numChanGroup_p[spw];
@@ -580,7 +580,6 @@ void ROVisibilityIterator::updateSlicer()
   //Fixed what i think was a confusion between chanWidth and chanInc
   // 2007/11/12
   Int start=chanStart_p[spw]+curChanGroup_p*chanWidth_p[spw];
-  start-=msIter_p.startChan();
   AlwaysAssert(start>=0 && start+channelGroupSize_p<=nChan_p,AipsError);
   //  slicer_p=Slicer(Slice(),Slice(start,channelGroupSize_p));
   // above is slow, use IPositions instead.
@@ -1098,7 +1097,7 @@ ROVisibilityIterator::frequency(Vector<Double>& freq) const
             Int spw = msIter_p.spectralWindowId();
             This->frequency_p.resize(channelGroupSize_p);
             const Vector<Double>& chanFreq=msIter_p.frequency();
-            Int start=chanStart_p[spw]-msIter_p.startChan();
+            Int start=chanStart_p[spw];
             Int inc=chanInc_p[spw] <= 0 ? 1 : chanInc_p[spw];
             for (Int i=0; i<channelGroupSize_p; i++) {
                 This->frequency_p(i)=chanFreq(start+curChanGroup_p*chanWidth_p[spw]+i*inc);
@@ -2271,7 +2270,7 @@ ROVisibilityIterator::lsrFrequency (const Int& spw,
     chanFreq = chanFreqs (spw);
 
     //chanFreq=msIter_p.msColumns().spectralWindow().chanFreq()(spw);
-    //      Int start=chanStart_p[spw]-msIter_p.startChan();
+    //      Int start=chanStart_p[spw];
     //Assuming that the spectral windows selected is not a reference ms from
     //visset ...as this will have a start chan offseted may be.
 


### PR DESCRIPTION
As per casacore PR #990 (https://github.com/casacore/casacore/pull/990) the support for obsolete CHANNEL_SELECTION keyword is removed and method MSIter::startChan() removed (it would otherwise always return 0).
This commit will eliminate any call to startChan() and remove adding the unused CHANNEL_SELECTION keyword.
This is similar to the work done in CASA itself (ticket CAS-12864).