### PR TITLE
Remove deprecated

### DIFF
--- a/.travis/clang.docker
+++ b/.travis/clang.docker
@@ -37,10 +37,10 @@ RUN rsync -avz rsync://casa-rsync.nrao.edu/casa-data .
 #####################################################################
 RUN mkdir /src
 WORKDIR /src
-RUN wget https://github.com/casacore/casacore/archive/v3.2.1.tar.gz
-RUN tar xvf v3.2.1.tar.gz
-RUN mkdir casacore-3.2.1/build
-WORKDIR /src/casacore-3.2.1/build
+RUN wget https://github.com/casacore/casacore/archive/v3.3.0.tar.gz
+RUN tar xvf v3.3.0.tar.gz
+RUN mkdir casacore-3.3.0/build
+WORKDIR /src/casacore-3.3.0/build
 RUN cmake \
     -DUSE_FFTW3=ON \
     -DBUILD_TESTING=ON \
@@ -49,7 +49,6 @@ RUN cmake \
     -DBUILD_PYTHON=ON \
     -DBUILD_PYTHON3=ON \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} ../ \
-    -DBUILD_DEPRECATED=ON \
     -DDATA_DIR=/usr/share/casacore/data
 RUN make -j 4
 RUN make install

--- a/.travis/clang.docker
+++ b/.travis/clang.docker
@@ -43,7 +43,7 @@ RUN mkdir casacore-3.3.0/build
 WORKDIR /src/casacore-3.3.0/build
 RUN cmake \
     -DUSE_FFTW3=ON \
-    -DBUILD_TESTING=ON \
+    -DBUILD_TESTING=OFF \
     -DUSE_OPENMP=OFF \
     -DUSE_HDF5=ON \
     -DBUILD_PYTHON=ON \

--- a/.travis/gcc.docker
+++ b/.travis/gcc.docker
@@ -36,10 +36,10 @@ RUN rsync -avz rsync://casa-rsync.nrao.edu/casa-data .
 #####################################################################
 RUN mkdir /src
 WORKDIR /src
-RUN wget https://github.com/casacore/casacore/archive/v3.2.1.tar.gz
-RUN tar xvf v3.2.1.tar.gz
-RUN mkdir casacore-3.2.1/build
-WORKDIR /src/casacore-3.2.1/build
+RUN wget https://github.com/casacore/casacore/archive/v3.3.0.tar.gz
+RUN tar xvf v3.3.0.tar.gz
+RUN mkdir casacore-3.3.0/build
+WORKDIR /src/casacore-3.3.0/build
 RUN cmake \
     -DUSE_FFTW3=ON \
     -DBUILD_TESTING=ON \
@@ -48,7 +48,6 @@ RUN cmake \
     -DBUILD_PYTHON=ON \
     -DBUILD_PYTHON3=ON \
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} ../ \
-    -DBUILD_DEPRECATED=ON \
     -DDATA_DIR=/usr/share/casacore/data
 RUN make -j 4
 RUN make install

--- a/.travis/gcc.docker
+++ b/.travis/gcc.docker
@@ -42,7 +42,7 @@ RUN mkdir casacore-3.3.0/build
 WORKDIR /src/casacore-3.3.0/build
 RUN cmake \
     -DUSE_FFTW3=ON \
-    -DBUILD_TESTING=ON \
+    -DBUILD_TESTING=OFF \
     -DUSE_OPENMP=OFF \
     -DUSE_HDF5=ON \
     -DBUILD_PYTHON=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ include (CTest)
 # Determine which external packages to use.
 # dependencies
 find_package(CasaCore 3.2 REQUIRED)
-add_definitions(-DAIPS_USE_DEPRECATED) # until such time that we can fully port this package
 find_package(CFITSIO 3.030 REQUIRED) # Should pad to three decimal digits
 find_package(WCSLIB 4.7 REQUIRED)    # needed for CASA
 find_package(BLAS REQUIRED)

--- a/msvis/MSVis/VisImagingWeight.h
+++ b/msvis/MSVis/VisImagingWeight.h
@@ -28,7 +28,6 @@
 
 #ifndef VISIMAGINGWEIGHT_H
 #define VISIMAGINGWEIGHT_H
-#include <casacore/casa/Containers/SimOrdMap.h>
 #include <casacore/casa/aips.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/Quanta/Quantum.h>


### PR DESCRIPTION
All work was already done to remove the deprecated casacore functions. Only one forgotten include caused all builds to fail..