### PR TITLE
Casacore 3.4 conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ add_definitions(-DCASA_STANDALONE)
 
 # -------- library building ----------------------------
 INCLUDE_DIRECTORIES(${CASACORE_INCLUDE_DIR} 
-    ${CASACORE_INCLUDE_DIR}/casacore
+    ${CASACORE_INCLUDE_DIR}
     ${CFITSIO_INCLUDE_DIR}
     ${WCSLIB_INCLUDE_DIR}
     ${HDF5_INCLUDE_DIRS}

--- a/calibration/CalTables/CalSet.tcc
+++ b/calibration/CalTables/CalSet.tcc
@@ -223,17 +223,17 @@ template<class T> void CalSet<T>::inflate() {
       fieldId_[ispw]      = new Vector<Int>(ntime,-1);
 
       IPosition parshape(4,nPar_,nChan_(ispw),nElem_,ntime);
-      par_[ispw]     = new Array<T>(parshape,1.0);
+      par_[ispw]     = new Array<T>(parshape,static_cast<T>(1.0));
       parOK_[ispw]   = new Array<Bool>(parshape,False);
-      parErr_[ispw]  = new Array<Float>(parshape,0.0);
-      parSNR_[ispw]  = new Array<Float>(parshape,0.0);
+      parErr_[ispw]  = new Array<Float>(parshape,0.0f);
+      parSNR_[ispw]  = new Array<Float>(parshape,0.0f);
 
       //      iSolutionOK_[ispw]  = new Matrix<Bool>(nElem_,ntime,False);
-      iFit_[ispw]         = new Matrix<Float>(nElem_,ntime,0.0);
-      iFitwt_[ispw]       = new Matrix<Float>(nElem_,ntime,0.0);
+      iFit_[ispw]         = new Matrix<Float>(nElem_,ntime,0.0f);
+      iFitwt_[ispw]       = new Matrix<Float>(nElem_,ntime,0.0f);
       solutionOK_[ispw]   = new Vector<Bool>(ntime,False);
-      fit_[ispw]          = new Vector<Float>(ntime,0.0);
-      fitwt_[ispw]        = new Vector<Float>(ntime,0.0);
+      fit_[ispw]          = new Vector<Float>(ntime,0.0f);
+      fitwt_[ispw]        = new Vector<Float>(ntime,0.0f);
     }
   }
 
@@ -635,7 +635,7 @@ template<class T> void CalSet<T>::store (const String& file,
 	Vector <Int> spwId(1,iSpw);
 	Matrix <Double> chanFreq(ip, dzero); 
 	Matrix <Double> chanWidth(ip, dzero);
-	Array <String> polznType(ip, "");
+	Array <String> polznType(ip, String(""));
 	Cube <Int> chanRange(IPosition(3,2,1,maxNumChan), 0);
 	Vector <Int> numChan(1,nChan_(iSpw));
 	for (Int ichan=0; ichan<nChan_(iSpw); ichan++) {

--- a/components/ComponentModels/ComponentList.cc
+++ b/components/ComponentModels/ComponentList.cc
@@ -906,8 +906,8 @@ void ComponentList::writeTable() {
     if (nRows < nelem) {
       itsTable.addRow(nelem - nRows);
     } else if (nRows > nelem) {
-      Vector<uInt> rows(nRows - nelem);
-      indgen(rows, nelem);
+      Vector<rownr_t> rows(nRows - nelem);
+      indgen(rows, static_cast<rownr_t>(nelem));
       itsTable.removeRow(rows);
     }
   }

--- a/components/ComponentModels/ComponentList.h
+++ b/components/ComponentModels/ComponentList.h
@@ -36,6 +36,7 @@
 #include <casacore/measures/Measures/MFrequency.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/tables/Tables/Table.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -45,7 +46,6 @@ class MVDirection;
 class MVFrequency;
 class MVAngle;
 class Unit;
-template <class T> class Vector;
 template <class Ms> class MeasRef;
 
 // <summary> A class for manipulating groups of components </summary>

--- a/components/ComponentModels/ComponentShape.h
+++ b/components/ComponentModels/ComponentShape.h
@@ -34,6 +34,8 @@
 #include <casacore/casa/Quanta/Quantum.h>
 #include <casacore/casa/Utilities/RecordTransformable.h>
 #include <components/ComponentModels/ComponentType.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -41,9 +43,7 @@ class DirectionCoordinate;
 class MVAngle;
 class RecordInterface;
 class String;
-template <class T> class Matrix;
 template <class T> class MeasRef;
-template <class T> class Vector;
 
 // <summary>Base class for component shapes</summary>
 

--- a/components/ComponentModels/ConstantSpectrum.h
+++ b/components/ComponentModels/ConstantSpectrum.h
@@ -31,13 +31,14 @@
 #include <casacore/casa/aips.h>
 #include <components/ComponentModels/ComponentType.h>
 #include <components/ComponentModels/SpectralModel.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class MFrequency;
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>Model the spectral variation with a constant</summary>
 

--- a/components/ComponentModels/DiskShape.h
+++ b/components/ComponentModels/DiskShape.h
@@ -33,14 +33,14 @@
 #include <casacore/casa/BasicSL/Complex.h>
 #include <components/ComponentModels/ComponentType.h>
 #include <components/ComponentModels/TwoSidedShape.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class MDirection;
 class MVAngle;
 template <class Qtype> class Quantum;
-template <class T> class Matrix;
-template <class T> class Vector;
 
 // <summary>A disk model for the spatial distribution of emission</summary>
 

--- a/components/ComponentModels/FluxCalc_SS_JPL_Butler.cc
+++ b/components/ComponentModels/FluxCalc_SS_JPL_Butler.cc
@@ -263,8 +263,8 @@ Bool FluxCalc_SS_JPL_Butler::readEphem()
        << "\n\tin " << edir
        << LogIO::POST;
   
-    Directory hordir(edir);
-    DirectoryIterator dirIter(hordir, tabpat);
+    const Directory hordir(edir);
+    DirectoryIterator dirIter(hordir, Regex(tabpat));
     uInt firstTimeStart = name_p.length() + 1;  // The + 1 is for the _.
     Regex timeUnitPat("[ydhms]");
 
@@ -775,8 +775,8 @@ void FluxCalc_SS_JPL_Butler::compute_venus(Vector<Flux<Double> >& values,
   // Just let it extrapolate if necessary; the temperature_p given in the
   // ephemeris (735K) is so high that I think it's for the surface.
   InterpolateArray1D<Float, Double>::interpolate(temps, ghzfreqs,
-						 Vector<Float>(measfreqblk),
-						 Vector<Double>(meastbblk),
+						 Vector<Float>(measfreqblk.begin(), measfreqblk.end()),
+						 Vector<Double>(meastbblk.begin(), meastbblk.end()),
 						 InterpolateArray1D<Float, Double>::cubic);
 
   if(minfreq < 0.303)

--- a/components/ComponentModels/GaussianShape.h
+++ b/components/ComponentModels/GaussianShape.h
@@ -34,14 +34,13 @@
 #include <casacore/casa/BasicSL/Complex.h>
 #include <components/ComponentModels/ComponentType.h>
 #include <components/ComponentModels/TwoSidedShape.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class MDirection;
 class MVAngle;
 template <class Qtype> class Quantum;
-template <class T> class Matrix;
-template <class T> class Vector;
 
 // <summary>A Gaussian model for the spatial distribution of emission</summary>
 

--- a/components/ComponentModels/LimbDarkenedDiskShape.h
+++ b/components/ComponentModels/LimbDarkenedDiskShape.h
@@ -29,6 +29,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <components/ComponentModels/TwoSidedShape.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -36,8 +37,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 class MDirection;
 class MVAngle;
 template <class Qtype> class Quantum;
-template <class T> class Matrix;
-template <class T> class Vector;
 
 // <summary>A limb-darkened disk model for the spatial distribution of emission</summary>
 

--- a/components/ComponentModels/PointShape.h
+++ b/components/ComponentModels/PointShape.h
@@ -33,6 +33,7 @@
 #include <components/ComponentModels/ComponentShape.h>
 #include <components/ComponentModels/ComponentType.h>
 #include <casacore/casa/BasicSL/Complex.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -40,7 +41,6 @@ class MVAngle;
 class MDirection;
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>A shape where emission comes from only one direction</summary>
 

--- a/components/ComponentModels/SkyCompBase.h
+++ b/components/ComponentModels/SkyCompBase.h
@@ -33,6 +33,7 @@
 #include <components/ComponentModels/ComponentType.h>
 #include <casacore/casa/Utilities/RecordTransformable.h>
 #include <casacore/casa/BasicSL/Complexfwd.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -47,9 +48,6 @@ class ComponentShape;
 class SpectralModel;
 class Unit;
 template <class T> class Flux;
-template <class T> class Vector;
-template <class T> class Matrix;
-template <class T> class Cube;
 template <class Ms> class MeasRef;
 
 // <summary>Base class for model components of the sky brightness</summary>

--- a/components/ComponentModels/SkyCompRep.h
+++ b/components/ComponentModels/SkyCompRep.h
@@ -36,6 +36,7 @@
 #include <casacore/casa/Utilities/CountedPtr.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/measures/Measures/Stokes.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -54,8 +55,6 @@ class TwoSidedShape;
 class Unit;
 class GaussianBeam;
 template <class Ms> class MeasRef;
-template <class T> class Cube;
-template <class T> class Vector;
 template <class T> class Quantum;
 
 

--- a/components/ComponentModels/SkyComponent.h
+++ b/components/ComponentModels/SkyComponent.h
@@ -35,6 +35,8 @@
 #include <components/ComponentModels/ComponentType.h>
 #include <components/ComponentModels/SkyCompBase.h>
 #include <casacore/measures/Measures/Stokes.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -52,8 +54,6 @@ class Unit;
 class GaussianBeam;
 template<class Ms> class MeasRef;
 template<class T> class Flux;
-template<class T> class Cube;
-template<class T> class Vector;
 template<class T> class Quantum;
 
 // <summary>A component of a model of the sky </summary>

--- a/components/ComponentModels/SpectralIndex.h
+++ b/components/ComponentModels/SpectralIndex.h
@@ -31,13 +31,13 @@
 #include <casacore/casa/aips.h>
 #include <components/ComponentModels/ComponentType.h>
 #include <components/ComponentModels/SpectralModel.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class MFrequency;
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>Models the spectral variation with a spectral index</summary>
 

--- a/components/ComponentModels/SpectralModel.h
+++ b/components/ComponentModels/SpectralModel.h
@@ -34,12 +34,12 @@
 #include <casacore/measures/Measures/MFrequency.h>
 #include <casacore/casa/Quanta/Unit.h>
 #include <casacore/casa/Quanta/Quantum.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>Base class for spectral models</summary>
 

--- a/components/ComponentModels/TabularSpectrum.h
+++ b/components/ComponentModels/TabularSpectrum.h
@@ -32,12 +32,13 @@
 #include <components/ComponentModels/ComponentType.h>
 #include <components/ComponentModels/SpectralModel.h>
 #include <components/ComponentModels/Flux.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class MFrequency;
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>Models the spectral variation with a spectral index</summary>
 

--- a/components/ComponentModels/TwoSidedShape.h
+++ b/components/ComponentModels/TwoSidedShape.h
@@ -35,6 +35,7 @@
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/Quanta/Unit.h>
 #include <casacore/casa/Quanta/Quantum.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -43,7 +44,6 @@ class MDirection;
 class MVAngle;
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>Base class for component shapes with two sides</summary>
 

--- a/components/ComponentModels/test/dSkyCompBase.cc
+++ b/components/ComponentModels/test/dSkyCompBase.cc
@@ -28,7 +28,7 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/measures/Measures/MDirection.h>
 #include <casacore/measures/Measures/MFrequency.h>

--- a/components/ComponentModels/test/dTwoSidedShape.cc
+++ b/components/ComponentModels/test/dTwoSidedShape.cc
@@ -40,7 +40,7 @@
 #include <casacore/casa/Quanta/Quantum.h>
 #include <casacore/casa/Quanta/MVAngle.h>
 #include <casacore/casa/Quanta/MVTime.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/BasicSL/String.h>
 #include <casacore/casa/iostream.h>
 

--- a/components/SpectralComponents/GaussianMultipletSpectralElement.cc
+++ b/components/SpectralComponents/GaussianMultipletSpectralElement.cc
@@ -26,7 +26,7 @@
 
 #include <components/SpectralComponents/GaussianMultipletSpectralElement.h>
 
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Containers/Record.h>

--- a/components/SpectralComponents/GaussianMultipletSpectralElement.h
+++ b/components/SpectralComponents/GaussianMultipletSpectralElement.h
@@ -125,7 +125,7 @@ public:
 	// between a non-reference Gaussian parameter and the corresponding reference
 	// Gaussian parameter.
 	GaussianMultipletSpectralElement(
-		const vector<GaussianSpectralElement>& estimates,
+		const std::vector<GaussianSpectralElement>& estimates,
 		const Matrix<Double>& fixedRelationships
 	);
 
@@ -148,7 +148,7 @@ public:
 	) const;
 
 	// get the gaussians
-	const vector<GaussianSpectralElement>& getGaussians() const;
+	const std::vector<GaussianSpectralElement>& getGaussians() const;
 
 	// get the constraints matrix
 	const Matrix<Double>& getConstraints() const;
@@ -171,7 +171,7 @@ public:
 	Bool toRecord(RecordInterface& out) const;
 
 private:
-	vector<GaussianSpectralElement> _gaussians;
+	std::vector<GaussianSpectralElement> _gaussians;
 	Matrix<Double> _constraints;
 	Matrix<uInt> _paramIndices;
 };

--- a/components/SpectralComponents/LogTransformedPolynomialSpectralElement.cc
+++ b/components/SpectralComponents/LogTransformedPolynomialSpectralElement.cc
@@ -28,6 +28,7 @@
 #include <components/SpectralComponents/LogTransformedPolynomialSpectralElement.h>
 
 #include <casacore/casa/iostream.h>
+#include <casacore/casa/Exceptions/Error.h>
 
 #define _ORIGIN  String("LogTransformedPolynomialSpectralElement::") + __FUNCTION__ + ":" + String::toString(__LINE__) + ": "
 

--- a/components/SpectralComponents/PCFSpectralElement.cc
+++ b/components/SpectralComponents/PCFSpectralElement.cc
@@ -69,7 +69,7 @@ PCFSpectralElement::PCFSpectralElement(
 PCFSpectralElement::PCFSpectralElement(
 	SpectralElement::Types type, Double amp,
 	Double center, Double width
-) : SpectralElement(type, vector<Double>(3)) {
+) : SpectralElement(type, std::vector<Double>(3)) {
 	_initFunction();
 	setAmpl(amp);
 	setCenter(center);

--- a/components/SpectralComponents/SpectralElement.cc
+++ b/components/SpectralComponents/SpectralElement.cc
@@ -37,7 +37,7 @@
 
 //debug only
 #include <casacore/scimath/Functionals/CompiledFunction.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 
 #include <casacore/casa/iostream.h>
 

--- a/components/SpectralComponents/SpectralElement2.cc
+++ b/components/SpectralComponents/SpectralElement2.cc
@@ -33,6 +33,8 @@
 #include <components/SpectralComponents/PowerLogPolynomialSpectralElement.h>
 
 #include <casacore/casa/iostream.h>
+#include <casacore/casa/Exceptions/Error.h>
+#include <casacore/casa/BasicMath/Math.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/components/SpectralComponents/SpectralElementFactory.cc
+++ b/components/SpectralComponents/SpectralElementFactory.cc
@@ -196,7 +196,7 @@ SpectralElement* SpectralElementFactory::fromRecord(
 		}
 		Record gaussians = in.asRecord("gaussians");
 		uInt i = 0;
-		vector<GaussianSpectralElement> comps(0);
+		std::vector<GaussianSpectralElement> comps(0);
 		while(True) {
 			String id = "*" + String::toString(i);
 			if (gaussians.isDefined(id)) {

--- a/components/SpectralComponents/SpectralEstimate.h
+++ b/components/SpectralComponents/SpectralEstimate.h
@@ -32,12 +32,13 @@
 #include <casacore/casa/aips.h>
 #include <components/SpectralComponents/SpectralElement.h>
 #include <components/SpectralComponents/SpectralList.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
 class GaussianSpectralElement;
-template <class T> class Vector;
 
 // <summary>
 // Get an initial estimate for spectral lines

--- a/components/SpectralComponents/SpectralFit.h
+++ b/components/SpectralComponents/SpectralFit.h
@@ -32,12 +32,12 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <components/SpectralComponents/SpectralList.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
 class SpectralElement;
-template <class T> class Vector;
 
 // <summary>
 // Least Squares fitting of spectral elements to spectrum

--- a/components/SpectralComponents/SpectralList.h
+++ b/components/SpectralComponents/SpectralList.h
@@ -32,6 +32,7 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Containers/Block.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -39,7 +40,6 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 class SpectralElement;
 class RecordInterface;
 class String;
-template <class T> class Vector;
 
 // <summary>
 // A set of SpectralElements

--- a/components/SpectralComponents/test/tGaussianMultipletSpectralElement.cc
+++ b/components/SpectralComponents/test/tGaussianMultipletSpectralElement.cc
@@ -35,7 +35,7 @@
 #include <components/SpectralComponents/SpectralElementFactory.h>
 
 #include <casacore/casa/Utilities/Assert.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 
 #include <casacore/casa/Arrays/Vector.h>
 

--- a/components/SpectralComponents/test/tLogTransformedPolynomialSpectralElement.cc
+++ b/components/SpectralComponents/test/tLogTransformedPolynomialSpectralElement.cc
@@ -26,13 +26,14 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/BasicMath/Math.h>
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Utilities/PtrHolder.h>
 #include <components/SpectralComponents/LogTransformedPolynomialSpectralElement.h>
 #include <components/SpectralComponents/SpectralElementFactory.h>
 
 #include <casacore/casa/Utilities/Assert.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 
 #include <casacore/casa/Arrays/Vector.h>
 

--- a/components/SpectralComponents/test/tLorentzianSpectralElement.cc
+++ b/components/SpectralComponents/test/tLorentzianSpectralElement.cc
@@ -32,7 +32,7 @@
 #include <components/SpectralComponents/SpectralElementFactory.h>
 
 #include <casacore/casa/Utilities/Assert.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 
 #include <casacore/casa/Arrays/Vector.h>
 

--- a/components/SpectralComponents/test/tPowerLogPolynomialSpectralElement.cc
+++ b/components/SpectralComponents/test/tPowerLogPolynomialSpectralElement.cc
@@ -26,13 +26,14 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
+#include <casacore/casa/BasicMath/Math.h>
 #include <casacore/casa/Containers/Record.h>
 #include <casacore/casa/Utilities/PtrHolder.h>
 #include <components/SpectralComponents/PowerLogPolynomialSpectralElement.h>
 #include <components/SpectralComponents/SpectralElementFactory.h>
 
 #include <casacore/casa/Utilities/Assert.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 
 #include <casacore/casa/Arrays/Vector.h>
 

--- a/components/SpectralComponents/test/tSpectralFit.cc
+++ b/components/SpectralComponents/test/tSpectralFit.cc
@@ -29,7 +29,7 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/MaskArrLogi.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/BasicMath/Random.h>
 #include <casacore/casa/Containers/Record.h>

--- a/msvis/MSVis/MSUVWGenerator.cc
+++ b/msvis/MSVis/MSUVWGenerator.cc
@@ -8,6 +8,8 @@
 #include <casacore/ms/MeasurementSets/MSColumns.h>
 #include <casacore/ms/MeasurementSets/MSAntennaColumns.h>
 #include <casacore/measures/Measures/MCBaseline.h>
+#include <casacore/casa/BasicMath/Math.h>
+#include <casacore/casa/Utilities/GenSort.h>
 
 namespace casacore {
 

--- a/msvis/MSVis/MsAverager.cc
+++ b/msvis/MSVis/MsAverager.cc
@@ -417,7 +417,7 @@ void MsAverager::setAverager(
             Int field = vb.fieldId();
             Int arry = vb.arrayId();
 
-            Vector<uInt> rowNumber = vb.rowIds();
+            Vector<rownr_t> rowNumber = vb.rowIds();
             //cout << "rowIds=" << rowNumber << endl;
             for (int row = 0; row < nRow; row++) {
 

--- a/msvis/MSVis/VisBuffer.cc
+++ b/msvis/MSVis/VisBuffer.cc
@@ -1401,7 +1401,7 @@ Bool VisBuffer::timeRange(MEpoch & rTime, MVEpoch & rTimeEP,
 };
 
 
-Vector<uInt>& VisBuffer::rowIds()
+Vector<rownr_t>& VisBuffer::rowIds()
 {
   if (!rowIdsOK_p) {
 

--- a/msvis/MSVis/VisBuffer.h
+++ b/msvis/MSVis/VisBuffer.h
@@ -551,9 +551,9 @@ public:
 
     // Return the row Ids from the original ms. If the ms used is a subset of
     // another ms then rowIds() return the row ids of the original ms.
-    virtual Vector<uInt>& rowIds();
+    virtual Vector<rownr_t>& rowIds();
 
-    virtual const Vector<uInt>& rowIds() const {
+    virtual const Vector<rownr_t>& rowIds() const {
         return This->rowIds();
     };
 
@@ -881,7 +881,7 @@ private:
     MDirection phaseCenter_p;
     Int polFrame_p;
     Vector<Int> processorId_p;
-    Vector<uInt> rowIds_p;
+    Vector<rownr_t> rowIds_p;
     Vector<Int> scan_p;
     Vector<Float> sigma_p;
     Matrix<Float> sigmaMat_p;

--- a/msvis/MSVis/VisBufferAsync.cc
+++ b/msvis/MSVis/VisBufferAsync.cc
@@ -847,7 +847,7 @@ VisBufferAsync::setReceptor0Angle (const Vector<Float> & angles)
 }
 
 void
-VisBufferAsync::setRowIds (const Vector<uInt> & rowIds)
+VisBufferAsync::setRowIds (const Vector<rownr_t> & rowIds)
 {
     rowIds_p = rowIds;
 }

--- a/msvis/MSVis/VisBufferAsync.h
+++ b/msvis/MSVis/VisBufferAsync.h
@@ -50,8 +50,8 @@ public:
     Int numberCoh () const;
     virtual Vector<Float> parang(Double time) const;
     virtual Float parang0(Double time) const;
-    virtual Vector<uInt>& rowIds(){throw(AipsError("rowIds() not implemented for VBA."));}
-    virtual const Vector<uInt>& rowIds() const {throw(AipsError("rowIds() const not implemented for VBA."));}
+    virtual Vector<rownr_t>& rowIds(){throw(AipsError("rowIds() not implemented for VBA."));}
+    virtual const Vector<rownr_t>& rowIds() const {throw(AipsError("rowIds() const not implemented for VBA."));}
     virtual void setCorrectedVisCube(Complex c);
     virtual void setCorrectedVisCube (const Cube<Complex> & vis);
     virtual void setModelVisCube(Complex c);
@@ -104,7 +104,7 @@ protected:
     void setNAntennas (Int);
     void setNCoh (Int);
     void setReceptor0Angle (const Vector<Float> & receptor0Angle);
-    void setRowIds (const Vector<uInt> & rowIds);
+    void setRowIds (const Vector<rownr_t> & rowIds);
     void setSelectedNVisibilityChannels (const Vector<Int> & nVisibilityChannels);
     void setSelectedSpectralWindows (const Vector<Int> & spectralWindows);
     void setTopoFreqs (const Vector<Double> & lsrFreq, const Vector<Double> & selFreq_p);

--- a/msvis/MSVis/VisBufferAsyncWrapper.cc
+++ b/msvis/MSVis/VisBufferAsyncWrapper.cc
@@ -1183,14 +1183,14 @@ VisBufferAsyncWrapper::resetWeightMat ()
   wrappedVba_p->resetWeightMat ();
 }
 
-Vector<uInt>&
+Vector<rownr_t>&
 VisBufferAsyncWrapper::rowIds ()
 {
   CheckWrap ();
   return wrappedVba_p->rowIds ();
 }
 
-const Vector<uInt>&
+const Vector<rownr_t>&
 VisBufferAsyncWrapper::rowIds () const
 {
   CheckWrap ();

--- a/msvis/MSVis/VisBufferAsyncWrapper.h
+++ b/msvis/MSVis/VisBufferAsyncWrapper.h
@@ -342,9 +342,9 @@ public:
 
     // Return the row Ids from the original ms. If the ms used is a subset of
     // another ms then rowIds() return the row ids of the original ms.
-    virtual Vector<uInt>& rowIds();
+    virtual Vector<rownr_t>& rowIds();
 
-    virtual const Vector<uInt>& rowIds() const;;
+    virtual const Vector<rownr_t>& rowIds() const;;
 
     //</group>
 

--- a/msvis/MSVis/VisImagingWeight.h
+++ b/msvis/MSVis/VisImagingWeight.h
@@ -31,12 +31,11 @@
 #include <casacore/casa/aips.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/Quanta/Quantum.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 //#forward
 class ROVisibilityIterator;
-template<class T> class Matrix;
-template<class T> class Vector;
 
 // <summary>
 // Object to hold type of imaging weight scheme to be used on the fly and to provide

--- a/msvis/MSVis/VisIterator.cc
+++ b/msvis/MSVis/VisIterator.cc
@@ -177,8 +177,8 @@ void ROVisIterator::setSelTable()
     // Vector<Vector<Slice> > and a RefRows parameter to get-/putColumn.
     // Such put/get functions must be first implemented.
 
-    Vector<uInt> rows(curNumRow_p);
-    indgen(rows,uInt(curStartRow_p));
+    Vector<rownr_t> rows(curNumRow_p);
+    indgen(rows,static_cast<rownr_t>(curStartRow_p));
     selTable_p=msIter_p.table()(rows);
     attachColumns(attachTable());
 }
@@ -875,7 +875,7 @@ void VisIterator::putDataColumn(DataColumn whichOne,
   };
 };  
 
-Vector<uInt>& ROVisIterator::rowIds(Vector<uInt>& rowids) const
+Vector<rownr_t>& ROVisIterator::rowIds(Vector<rownr_t>& rowids) const
 {
   rowids.resize(curNumRow_p);
   rowids=selTable_p.rowNumbers();
@@ -904,9 +904,9 @@ void ROVisIterator::setTileCache()
   const ColumnDescSet& cds=thems.tableDesc().columnDescSet();
 
   // Get the first row number for this DDID.
-  Vector<uInt> rownums;
+  Vector<rownr_t> rownums;
   rowIds(rownums);
-  uInt startrow = rownums[0];
+  rownr_t startrow = rownums[0];
   
   Vector<String> columns(8);
   // complex

--- a/msvis/MSVis/VisIterator.h
+++ b/msvis/MSVis/VisIterator.h
@@ -200,7 +200,7 @@ public:
   // Return the row ids as from the original root table. This is useful 
   // to find correspondance between a given row in this iteration to the 
   // original ms row
-  virtual Vector<uInt>& rowIds(Vector<uInt>& rowids) const; 
+  virtual Vector<rownr_t>& rowIds(Vector<rownr_t>& rowids) const; 
 
   // Need to override this and not use getColArray
   virtual Vector<RigidVector<Double,3> >& uvw(Vector<RigidVector<Double,3> >& uvwvec) const;

--- a/msvis/MSVis/VisibilityIterator.cc
+++ b/msvis/MSVis/VisibilityIterator.cc
@@ -852,7 +852,7 @@ void ROVisibilityIterator::update_rowIds() const
   if (rowIds_p.nelements() == 0) {
       rowIds_p = selRows_p.convert();
       
-      Vector<uInt> msIter_rowIds(msIter_p.table().rowNumbers(msIter_p.ms()));
+      Vector<rownr_t> msIter_rowIds(msIter_p.table().rowNumbers(msIter_p.ms()));
 
       for (uInt i = 0; i < rowIds_p.nelements(); i++) {
           rowIds_p(i) = msIter_rowIds(rowIds_p(i));
@@ -911,7 +911,7 @@ ROVisibilityIterator::getReceptor0Angle ()
 	return receptor0Angle;
 }
 
-Vector<uInt>
+Vector<rownr_t>
 ROVisibilityIterator::getRowIds () const
 {
 	update_rowIds();
@@ -920,7 +920,7 @@ ROVisibilityIterator::getRowIds () const
 }
 
 
-Vector<uInt>& ROVisibilityIterator::rowIds(Vector<uInt>& rowids) const
+Vector<rownr_t>& ROVisibilityIterator::rowIds(Vector<rownr_t>& rowids) const
 {
   /* Calculate the row numbers in the original MS only when needed,
      i.e. when this function is called */

--- a/msvis/MSVis/VisibilityIterator.h
+++ b/msvis/MSVis/VisibilityIterator.h
@@ -471,7 +471,7 @@ public:
   // Return the row ids as from the original root table. This is useful 
   // to find correspondance between a given row in this iteration to the 
   // original ms row
-  virtual Vector<uInt>& rowIds(Vector<uInt>& rowids) const; 
+  virtual Vector<rownr_t>& rowIds(Vector<rownr_t>& rowids) const; 
 
   // Return the numbers of rows in the current chunk
   virtual Int nRowChunk() const;
@@ -601,7 +601,7 @@ public:
   MPosition getObservatoryPosition () const;
   MDirection getPhaseCenter () const;
   Vector<Float> getReceptor0Angle ();
-  Vector<uInt> getRowIds () const;
+  Vector<rownr_t> getRowIds () const;
 
   static void lsrFrequency (const Int& spw,
                             Vector<Double>& freq,
@@ -792,7 +792,7 @@ protected:
   Vector<Double> lsrFreq_p;
   String vInterpolation_p;
 
-  mutable Vector<uInt> rowIds_p;
+  mutable Vector<rownr_t> rowIds_p;
 
   ScalarColumn<Int> colAntenna1, colAntenna2;
   ScalarColumn<Int> colFeed1, colFeed2;

--- a/synthesis/Images/ImageFFT.cc
+++ b/synthesis/Images/ImageFFT.cc
@@ -31,7 +31,7 @@
 
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Arrays/Vector.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/Quanta/Unit.h>

--- a/synthesis/Images/ImageFFT.h
+++ b/synthesis/Images/ImageFFT.h
@@ -30,12 +30,12 @@
 
 #include <casacore/casa/aips.h>
 #include <casacore/images/Images/ImageInterface.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 class CoordinateSystem;
 class IPosition;
-template<class T> class Vector;
 
 // <summary>
 // FFT an image

--- a/synthesis/Images/ImagePolarimetry.cc
+++ b/synthesis/Images/ImagePolarimetry.cc
@@ -806,12 +806,12 @@ void ImagePolarimetry::rotationMeasure(ImageInterface<Float>*& rmOutPtr,
    }
 //
    Array<Bool> tmpMaskRM(IPosition(shapeRM.nelements(), 1), True);
-   Array<Float> tmpValueRM(IPosition(shapeRM.nelements(), 1), 0.0);
+   Array<Float> tmpValueRM(IPosition(shapeRM.nelements(), 1), 0.0f);
    Array<Bool> tmpMaskPA(IPosition(shapePA.nelements(), 1), True);
-   Array<Float> tmpValuePA(IPosition(shapePA.nelements(), 1), 0.0);
-   Array<Float> tmpValueNTurns(IPosition(shapeNTurns.nelements(), 1), 0.0);
+   Array<Float> tmpValuePA(IPosition(shapePA.nelements(), 1), 0.0f);
+   Array<Float> tmpValueNTurns(IPosition(shapeNTurns.nelements(), 1), 0.0f);
    Array<Bool> tmpMaskNTurns(IPosition(shapeNTurns.nelements(), 1), True);
-   Array<Float> tmpValueChiSq(IPosition(shapeChiSq.nelements(), 1), 0.0);
+   Array<Float> tmpValueChiSq(IPosition(shapeChiSq.nelements(), 1), 0.0f);
    Array<Bool> tmpMaskChiSq(IPosition(shapeChiSq.nelements(), 1), True);
 
 // Iterate

--- a/synthesis/MeasurementComponents/AWConvFunc.h
+++ b/synthesis/MeasurementComponents/AWConvFunc.h
@@ -37,10 +37,10 @@
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/Logging/LogSink.h>
 #include <casacore/casa/Logging/LogOrigin.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   //
   //-------------------------------------------------------------------------------------------

--- a/synthesis/MeasurementComponents/AzElAperture.h
+++ b/synthesis/MeasurementComponents/AzElAperture.h
@@ -33,6 +33,8 @@
 #include <synthesis/MeasurementComponents/ATerm.h>
 #include <synthesis/MeasurementComponents/Utils.h>
 #include <casacore/coordinates/Coordinates/CoordinateSystem.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 //
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
@@ -47,7 +49,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   class AzElAperture : public ATerm
   {

--- a/synthesis/MeasurementComponents/BeamSkyJones.cc
+++ b/synthesis/MeasurementComponents/BeamSkyJones.cc
@@ -56,7 +56,7 @@
 /*
 // temporary, for debugging
 #include <casacore/casa/Quanta/MVAngle.h>
-void printDirection(std::ostream &os,const casacore::MDirection &dir) throw (casacore::AipsError) {
+void printDirection(std::ostream &os,const casacore::MDirection &dir) {
   double lngbuf=dir.getValue().getLong("deg").getValue();
   if (lngbuf<0) lngbuf+=360.;
   os<<(dir.getRefString()!="GALACTIC"?casacore::MVAngle::Format(casacore::MVAngle::TIME):
@@ -212,7 +212,7 @@ Bool BeamSkyJones::changed(const VisBuffer& vb, Int row)
 // return True if two directions are close enough to consider the
 // operator unchanged, False otherwise
 Bool BeamSkyJones::directionsCloseEnough(const MDirection &dir1,
-                           const MDirection &dir2) const throw(AipsError)
+                           const MDirection &dir2) const 
 {
   Double sep; 
   if (dir1.getRef()!=dir2.getRef())

--- a/synthesis/MeasurementComponents/BeamSkyJones.h
+++ b/synthesis/MeasurementComponents/BeamSkyJones.h
@@ -327,7 +327,7 @@ protected:
   // return True if two directions are close enough to consider the
   // operator unchanged, False otherwise
   Bool directionsCloseEnough(const MDirection &dir1,
-                             const MDirection &dir2) const throw(AipsError);
+                             const MDirection &dir2) const;
   			     
   // return index of compareTelescope, compareAntenna and compareFeed in
   // myTelescopes_p, myAntennaIDs and myFeedIDs; -1 if not found

--- a/synthesis/MeasurementComponents/CFDefs.h
+++ b/synthesis/MeasurementComponents/CFDefs.h
@@ -28,6 +28,7 @@
 #ifndef SYNTHESIS_CFDEFS_H
 #define SYNTHESIS_CFDEFS_H
 #include <casacore/casa/Arrays/Array.h>
+#include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/aips.h>
 
 namespace casacore

--- a/synthesis/MeasurementComponents/EVLAAperture.h
+++ b/synthesis/MeasurementComponents/EVLAAperture.h
@@ -33,6 +33,8 @@
 //#include <synthesis/MeasurementComponents/ATerm.h>
 #include <synthesis/MeasurementComponents/AzElAperture.h>
 #include <casacore/coordinates/Coordinates/CoordinateSystem.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 //
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
@@ -47,7 +49,6 @@
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   //  class EVLAAperture : public ATerm
   class EVLAAperture : public AzElAperture

--- a/synthesis/MeasurementComponents/EVLAConvFunc.h
+++ b/synthesis/MeasurementComponents/EVLAConvFunc.h
@@ -40,18 +40,14 @@
 #include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/coordinates/Coordinates/SpectralCoordinate.h>
 #include <casacore/coordinates/Coordinates/StokesCoordinate.h>
-#if defined(casacore)
 #include <casacore/lattices/LatticeMath/LatticeFFT.h>
-#else
-#include <casacore/lattices/LatticeMath/LatticeFFT.h>
-#endif
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/Logging/LogSink.h>
 #include <casacore/casa/Logging/LogOrigin.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   class EVLAConvFunc : public ConvolutionFunction
   //: public PixelatedConvFunc<Complex>

--- a/synthesis/MeasurementComponents/HetArrayConvFunc.h
+++ b/synthesis/MeasurementComponents/HetArrayConvFunc.h
@@ -29,6 +29,7 @@
 #define SYNTHESIS_HETARRAYCONVFUNC_H
 
 #include <synthesis/MeasurementComponents/SimplePBConvFunc.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore{
 
@@ -51,7 +52,6 @@ namespace casacore{
   //</synopsis>
   //Forward declarations
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   class MosaicFT;
   class HetArrayConvFunc : public SimplePBConvFunc

--- a/synthesis/MeasurementComponents/SimplePBConvFunc.h
+++ b/synthesis/MeasurementComponents/SimplePBConvFunc.h
@@ -33,6 +33,8 @@
 #include <synthesis/MeasurementComponents/PBMathInterface.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Utilities/CountedPtr.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore{
 
@@ -55,7 +57,6 @@ namespace casacore{
   //</synopsis>
   //Forward declarations
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   class SkyJones;
   class CoordinateSystem;

--- a/synthesis/MeasurementComponents/Utils.cc
+++ b/synthesis/MeasurementComponents/Utils.cc
@@ -271,7 +271,7 @@ namespace casacore{
   //     (e.g. a change in the parallactic angle)
   
   // return True if a change occurs somewhere in the buffer
-  Bool IChangeDetector::changed(const VisBuffer &vb) const throw(AipsError)
+  Bool IChangeDetector::changed(const VisBuffer &vb) const
   {
      for (Int i=0;i<vb.nRow();++i)
           if (changed(vb,i)) return True;
@@ -282,7 +282,7 @@ namespace casacore{
   // up to row2 (row2=-1 means up to the end of the buffer). The row number,
   // where the change occurs is returned in the row2 parameter
   Bool IChangeDetector::changedBuffer(const VisBuffer &vb, Int row1, 
-		   Int &row2) const throw(AipsError)
+		   Int &row2) const
   {
     if (row1<0) row1=0;
     Int jrow = row2;
@@ -305,7 +305,7 @@ namespace casacore{
   }
   
   // a virtual destructor to make the compiler happy
-  IChangeDetector::~IChangeDetector() throw(AipsError) {}
+  IChangeDetector::~IChangeDetector() {}
   
   //
   /////////////////////////////////////////////////////////////////////////////
@@ -318,8 +318,8 @@ namespace casacore{
   
   // set up the tolerance, which determines how much the position angle should
   // change to report the change by this class
-  ParAngleChangeDetector::ParAngleChangeDetector(const Quantity &pa_tolerance) 
-               throw(AipsError) : pa_tolerance_p(pa_tolerance.getValue("rad")),
+  ParAngleChangeDetector::ParAngleChangeDetector(const Quantity &pa_tolerance) :
+               pa_tolerance_p(pa_tolerance.getValue("rad")),
 		    last_pa_p(1000.) {}  // 1000 is >> 2pi, so it is changed
                                          // after construction
   
@@ -329,13 +329,13 @@ namespace casacore{
     pa_tolerance_p = abs(pa_tolerance.getValue("rad"));
   }
   // reset to the state which exist just after construction
-  void ParAngleChangeDetector::reset() throw(AipsError)
+  void ParAngleChangeDetector::reset() 
   {
       last_pa_p=1000.; // it is >> 2pi, which would force a changed state
   }
      
   // return parallactic angle tolerance
-  Quantity ParAngleChangeDetector::getParAngleTolerance() const throw(AipsError)
+  Quantity ParAngleChangeDetector::getParAngleTolerance() const 
   {
       return Quantity(pa_tolerance_p,"rad");
   }
@@ -343,7 +343,7 @@ namespace casacore{
   // return True if a change occurs in the given row since the last call 
   // of update
   Bool ParAngleChangeDetector::changed(const VisBuffer &vb, Int row) 
-	        const throw(AipsError)
+	        const
   {
      if (row<0) row=0;
      //     const Double feed1_pa=vb.feed1_pa()[row];
@@ -367,7 +367,6 @@ namespace casacore{
   
   // start looking for a change from the given row of the VisBuffer
   void ParAngleChangeDetector::update(const VisBuffer &vb, Int row) 
-	         throw(AipsError)
   {
      if (row<0) row=0;
      const Double feed1_pa=vb.feed1_pa()[row];

--- a/synthesis/MeasurementComponents/Utils.h
+++ b/synthesis/MeasurementComponents/Utils.h
@@ -101,24 +101,24 @@ namespace casacore
   //
   struct IChangeDetector {
      // return True if a change occurs in the given row since the last call of update
-     virtual Bool changed(const VisBuffer &vb, Int row) const throw(AipsError) = 0;
+     virtual Bool changed(const VisBuffer &vb, Int row) const = 0;
      // start looking for a change from the given row of the VisBuffer
-     virtual void update(const VisBuffer &vb, Int row) throw(AipsError) = 0;
+     virtual void update(const VisBuffer &vb, Int row) = 0;
      
      // reset to the state which exists just after construction
-     virtual void reset() throw(AipsError) = 0;
+     virtual void reset() = 0;
 
      // some derived methods, which use the abstract virtual function changed(vb,row)
      
      // return True if a change occurs somewhere in the buffer
-     Bool changed(const VisBuffer &vb) const throw(AipsError);
+     Bool changed(const VisBuffer &vb) const;
      // return True if a change occurs somewhere in the buffer starting from row1
      // up to row2 (row2=-1 means up to the end of the buffer). The row number, 
      // where the change occurs is returned in the row2 parameter
-     Bool changedBuffer(const VisBuffer &vb, Int row1, Int &row2) const throw(AipsError);
+     Bool changedBuffer(const VisBuffer &vb, Int row1, Int &row2) const;
   protected:
      // a virtual destructor to make the compiler happy
-     virtual ~IChangeDetector() throw(AipsError);
+     virtual ~IChangeDetector();
   };
   //
   //////////////////////////////////////////////////////////////////////////////
@@ -137,21 +137,21 @@ namespace casacore
      ParAngleChangeDetector():pa_tolerance_p(0.0) {};
      // set up the tolerance, which determines how much the position angle should
      // change to report the change by this class
-     ParAngleChangeDetector(const Quantity &pa_tolerance) throw(AipsError);
+     ParAngleChangeDetector(const Quantity &pa_tolerance);
 
      virtual void setTolerance(const Quantity &pa_tolerance);
      // reset to the state which exists just after construction
-     virtual void reset() throw(AipsError);
+     virtual void reset();
 
      // return parallactic angle tolerance
-     Quantity getParAngleTolerance() const throw(AipsError);
+     Quantity getParAngleTolerance() const;
       
      // implementation of the base class' virtual functions
      
      // return True if a change occurs in the given row since the last call of update
-     virtual Bool changed(const VisBuffer &vb, Int row) const throw(AipsError);
+     virtual Bool changed(const VisBuffer &vb, Int row) const;
      // start looking for a change from the given row of the VisBuffer
-     virtual void update(const VisBuffer &vb, Int row) throw(AipsError);
+     virtual void update(const VisBuffer &vb, Int row);
   };
 
   //

--- a/synthesis/MeasurementComponents/WOnlyConvFunc.h
+++ b/synthesis/MeasurementComponents/WOnlyConvFunc.h
@@ -68,7 +68,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
     virtual void setPolMap(const Vector<Int>& polMap) {wTerm_p->setPolMap(polMap);};
 
     virtual Bool findSupport(Array<Complex>& func, Float& threshold,Int& origin, Int& R);
-
+    /*
     //
     // Pedgree baggage (NoOps).  
     //
@@ -80,6 +80,7 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
 			     const ImageInterface<Complex>& image,
 			     ImageInterface<Complex>& theavgPB,
 			     Bool reset=True) {};
+    */
   protected:
     void setSupport(Array<Complex>& convFunc, CFStore& cfs);
 

--- a/synthesis/MeasurementComponents/WOnlyConvFunc.h
+++ b/synthesis/MeasurementComponents/WOnlyConvFunc.h
@@ -38,10 +38,10 @@
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/Logging/LogSink.h>
 #include <casacore/casa/Logging/LogOrigin.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
   //
   //-------------------------------------------------------------------------------------------

--- a/synthesis/MeasurementComponents/WPConvFunc.h
+++ b/synthesis/MeasurementComponents/WPConvFunc.h
@@ -34,6 +34,7 @@
 #include <synthesis/MeasurementComponents/PixelatedConvFunc.h>
 #include <casacore/casa/Containers/Block.h>
 #include <casacore/casa/Utilities/CountedPtr.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore{
 
@@ -54,7 +55,6 @@ namespace casacore{
   // this class and related ones provide and cache  such functions for re-use 
   //</synopsis>
   template<class T> class ImageInterface;
-  template<class T> class Matrix;
   class VisBuffer;
 
   class WPConvFunc : public PixelatedConvFunc<Complex>

--- a/synthesis/MeasurementEquations/CEMemProgress.h
+++ b/synthesis/MeasurementEquations/CEMemProgress.h
@@ -35,11 +35,11 @@
 #include <casacore/lattices/Lattices/TempLattice.h>
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
-template <class T> class Vector;
 class PGPlotter;
 
 // <summary>

--- a/synthesis/MeasurementEquations/ClarkCleanLatModel.h
+++ b/synthesis/MeasurementEquations/ClarkCleanLatModel.h
@@ -36,11 +36,11 @@
 #include <casacore/casa/Arrays/IPosition.h>
 #include <synthesis/MeasurementEquations/Iterate.h>
 #include <casacore/casa/Logging/LogIO.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
-template <class T> class Matrix;
-template <class T> class Vector;
 class ClarkCleanProgress;
 class LatConvEquation;
 class CCList;

--- a/synthesis/MeasurementEquations/ClarkCleanModel.cc
+++ b/synthesis/MeasurementEquations/ClarkCleanModel.cc
@@ -35,6 +35,7 @@
 #include <casacore/casa/Arrays/ArrayError.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/VectorIter.h>
+#include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Logging/LogOrigin.h>
 #include <casacore/casa/Exceptions/Error.h>
 #include <casacore/casa/Utilities/Assert.h>
@@ -885,7 +886,7 @@ Float ClarkCleanModel::getPsfPatch(Array<Float>& psfPatch,
   // maximum size use it.
   IPosition psfPatchSize;
   if (thePsfPatchSize.nelements() != 0) {
-    psfPatchSize = min(maxSize.asVector(),
+    psfPatchSize = casacore::min(maxSize.asVector(),
 		       thePsfPatchSize.asVector());
   }
   else {

--- a/synthesis/MeasurementEquations/ClarkCleanProgress.h
+++ b/synthesis/MeasurementEquations/ClarkCleanProgress.h
@@ -35,11 +35,12 @@
 #include <casacore/lattices/Lattices/TempLattice.h>
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
-template <class T> class Vector;
 class PGPlotter;
 
 // <summary>

--- a/synthesis/MeasurementEquations/ConvolutionEquation.cc
+++ b/synthesis/MeasurementEquations/ConvolutionEquation.cc
@@ -28,6 +28,7 @@
 #include <synthesis/MeasurementEquations/ConvolutionEquation.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/Vector.h>
+#include <casacore/casa/BasicMath/Math.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
@@ -96,7 +97,7 @@ Bool ConvolutionEquation::evaluate(Array<Float> & result,
       IPosition newtrc(thePsf.ndim(), 0);
       IPosition newblc(thePsf.ndim(), 0);
       for(uInt i = 0; i < thePsf.ndim(); i++){
-	newblc(i) = -min(blc(i), 0);
+	newblc(i) = -std::min(blc(i), static_cast<ssize_t>(0));
 	newSize(i) = std::max(trc(i)+1, psfSize(i)) + newblc(i);
 	newtrc(i) = newblc(i) + psfSize(i) - 1;
       }

--- a/synthesis/MeasurementEquations/ImageMSCleaner.h
+++ b/synthesis/MeasurementEquations/ImageMSCleaner.h
@@ -31,11 +31,11 @@
 
 //# Includes
 #include <synthesis/MeasurementEquations/MatrixCleaner.h>
+#include <casacore/casa/Arrays/ArrayFwd.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 
 //# Forward Declarations
-template <class T> class Matrix;
 template <class T> class ImageInterface;
 
 

--- a/synthesis/MeasurementEquations/Imager.cc
+++ b/synthesis/MeasurementEquations/Imager.cc
@@ -469,7 +469,7 @@ Imager::~Imager()
     if(mess.contains("does not exist") && mess.contains("TempLattice")){
       String rootpath="/"+String(mess.after("/")).before("TempLattice");
       String pid=String(mess.after("TempLattice")).before("_");
-      DirectoryIterator dir(rootpath, Regex::fromPattern("TempLattice"+pid+"*"));
+      DirectoryIterator dir(rootpath, Regex(Regex::fromPattern("TempLattice"+pid+"*")));
       while(!dir.pastEnd()){
 	  Directory ledir(rootpath+"/"+dir.name());
 	  ledir.removeRecursive();

--- a/synthesis/MeasurementEquations/Imager.cc
+++ b/synthesis/MeasurementEquations/Imager.cc
@@ -478,11 +478,13 @@ Imager::~Imager()
       }
 
     }
+    /*
+    // exception in destructor will cause termination
     else{
       throw(AipsError(x));
 
     }
-
+    */
   }
 
 

--- a/synthesis/MeasurementEquations/MatrixCleaner.cc
+++ b/synthesis/MeasurementEquations/MatrixCleaner.cc
@@ -28,7 +28,7 @@
 #include <casacore/casa/Arrays/Cube.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/MatrixMath.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/BasicMath/Math.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/Logging/LogIO.h>

--- a/synthesis/MeasurementEquations/MatrixCleaner.h
+++ b/synthesis/MeasurementEquations/MatrixCleaner.h
@@ -36,16 +36,11 @@
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Containers/Block.h>
-#if defined(casacore)
 #include <casacore/lattices/LatticeMath/LatticeCleaner.h>
-#else
-#include <casacore/lattices/LatticeMath/LatticeCleaner.h>
-#endif
+#include <casacore/casa/Arrays/ArrayFwd.h>
+
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
-
-//# Forward Declarations
-template <class T> class Matrix;
 
 // <summary>A copy of LatticeCleaner but just using 2-D matrices</summary>
 // <synopsis> It is a mimic of the LatticeCleaner class but avoid a lot of 

--- a/synthesis/MeasurementEquations/MultiTermMatrixCleaner.cc
+++ b/synthesis/MeasurementEquations/MultiTermMatrixCleaner.cc
@@ -29,7 +29,7 @@
 #include <casacore/casa/Arrays/Cube.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Arrays/MatrixMath.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 #include <casacore/casa/BasicMath/Math.h>
 #include <casacore/casa/BasicSL/Complex.h>
 #include <casacore/casa/Logging/LogIO.h>

--- a/synthesis/MeasurementEquations/StokesImageUtil.cc
+++ b/synthesis/MeasurementEquations/StokesImageUtil.cc
@@ -47,7 +47,7 @@
 #include <casacore/lattices/Lattices/LatticeStepper.h>
 #include <casacore/scimath/Fitting/NonLinearFitLM.h>
 #include <casacore/scimath/Functionals/Gaussian2D.h>
-#include <casacore/casa/Arrays/ArrayIO.h>
+#include <casacore/casa/IO/ArrayIO.h>
 
 #include <casacore/ms/MeasurementSets/MSColumns.h>
 #include <casacore/ms/MeasurementSets/MSDopplerUtil.h>

--- a/synthesis/Parallel/PTransport.h
+++ b/synthesis/Parallel/PTransport.h
@@ -32,6 +32,9 @@
 //# Includes
 #include <casacore/casa/aips.h>
 #include <casacore/casa/Arrays/Array.h>
+#include <casacore/casa/BasicSL/Complex.h>
+#include <casacore/casa/BasicSL/String.h>
+#include <casacore/casa/Containers/Block.h>
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 

--- a/synthesis/apps/lwimager.cc
+++ b/synthesis/apps/lwimager.cc
@@ -32,6 +32,7 @@
 #include <casacore/images/Images/HDF5Image.h>
 #include <casacore/images/Images/ImageFITSConverter.h>
 #include <casacore/casa/Inputs.h>
+#include <casacore/casa/Arrays/Vector.h>
 #include <casacore/casa/Arrays/ArrayUtil.h>
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/Utilities/Regex.h>
@@ -154,6 +155,14 @@ void makeEmpty (Imager& imager, const String& imgName, Int fieldid)
   String name(imgName);
   imager.makeEmptyImage(coords, name, fieldid);
   imager.unlock();
+}
+
+// casacore-3.4 doesn't have vector constructor from block anymore. Unfortunately, Input interface returns
+// Block<some_type>. This template encapsulates conversion to minimise contamination of the code.
+template<typename T>
+Vector<T> block2vector(const Block<T> &in) 
+{
+  return Vector<T>(in.begin(), in.end());
 }
 
 int main (Int argc, char** argv)
@@ -342,19 +351,19 @@ int main (Int argc, char** argv)
     Bool preferVelocity = inputs.getBool("prefervelocity");
     Long cachesize   = inputs.getInt("cachesize");
     Int fieldid      = inputs.getInt("field");
-    Vector<Int> spwid(inputs.getIntArray("spwid"));
+    Vector<Int> spwid(block2vector(inputs.getIntArray("spwid")));
     Int npix         = inputs.getInt("npix");
     Int nfacet       = inputs.getInt("nfacets");
-    Vector<Int> nchan(inputs.getIntArray("nchan"));
-    Vector<Int> chanstart(inputs.getIntArray("chanstart"));
-    Vector<Int> chanstep(inputs.getIntArray("chanstep"));
+    Vector<Int> nchan(block2vector(inputs.getIntArray("nchan")));
+    Vector<Int> chanstart(block2vector(inputs.getIntArray("chanstart")));
+    Vector<Int> chanstep(block2vector(inputs.getIntArray("chanstep")));
     Int img_nchan    = inputs.getInt("img_nchan");
     Int img_start    = inputs.getInt("img_chanstart");
     Int img_step     = inputs.getInt("img_chanstep");
     Int wplanes      = inputs.getInt("wprojplanes");
     Int niter        = inputs.getInt("niter");
     Int nscales      = inputs.getInt("nscales");
-    Vector<Double> userScaleSizes(inputs.getDoubleArray("uservector"));
+    Vector<Double> userScaleSizes(block2vector(inputs.getDoubleArray("uservector")));
     Double padding   = inputs.getDouble("padding");
     Double gain      = inputs.getDouble("gain");
     Double maskValue = inputs.getDouble("maskvalue");


### PR DESCRIPTION
I have made changes to casarest to bring it in line with casacore-3.4 (largely changes to includes, but also table row number type and block-based constructor of the vector). There is also some cleanup of compiler warnings. 

It seems practical to have a separate release of casarest once these changes are merged - the current most recent casarest-1.7.0 release is still required to build with older versions of casacore, but is not compatible with casacore-3.4.