### PR TITLE
Casacore 3.7.1 transition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(HDF5_ROOT_DIR)
 # project version
 set( ${PROJECT_NAME}_MAJOR_VERSION 1 )
 set( ${PROJECT_NAME}_MINOR_VERSION 9 )
-set( ${PROJECT_NAME}_PATCH_LEVEL 0 )
+set( ${PROJECT_NAME}_PATCH_LEVEL 1 )
 
 if (UseCasaNamespace)
     add_definitions (-DUseCasaNamespace)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 project(casarest)
 enable_language(CXX Fortran)
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.14.0)
 include(CheckCXXCompilerFlag)
 #list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake)
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+# Require a C++17 compatible compiler
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 
 # rpath setup for libraries
 

--- a/flagging/Flagging/Flagger.cc
+++ b/flagging/Flagging/Flagger.cc
@@ -1654,9 +1654,9 @@ namespace casacore {
             
 		  sprintf(subtitle,"pass %d (data)",npass+1);
 
-                  std::auto_ptr<ProgressMeter> progmeter(NULL);
+                  std::unique_ptr<ProgressMeter> progmeter;
                   if (chunk.num(TIME) > progmeter_limit) {
-                      progmeter = std::auto_ptr<ProgressMeter>(new ProgressMeter(1.0,static_cast<Double>(chunk.num(TIME)+0.001),title+subtitle,"","","",True,pm_update_freq));
+                      progmeter.reset(new ProgressMeter(1.0,static_cast<Double>(chunk.num(TIME)+0.001),title+subtitle,"","","",True,pm_update_freq));
                   }
 
 		  // start pass for all active agents
@@ -1670,7 +1670,7 @@ namespace casacore {
 		  // iterate over visbuffers
 		  for( vi.origin(); vi.more() && nactive; vi++,itime++ ) {
 
-                    if (progmeter.get() != NULL) {
+                    if (progmeter) {
                         progmeter->update(itime);
                     }
 		    chunk.newTime();
@@ -1755,9 +1755,9 @@ namespace casacore {
 		  sprintf(subtitle,"pass %d (dry)",npass+1);
                   //cout << "-----------subtitle=" << subtitle << endl;
 
-                  std::auto_ptr<ProgressMeter> progmeter(NULL);
+                  std::unique_ptr<ProgressMeter> progmeter;
                   if (chunk.num(TIME) > progmeter_limit) {
-                      progmeter = std::auto_ptr<ProgressMeter>(new ProgressMeter (1.0,static_cast<Double>(chunk.num(TIME)+0.001),title+subtitle,"","","",True,pm_update_freq));
+                      progmeter.reset(new ProgressMeter (1.0,static_cast<Double>(chunk.num(TIME)+0.001),title+subtitle,"","","",True,pm_update_freq));
                   }
 		  // start pass for all active agents
 		  for( uInt ival = 0; ival<acc.size(); ival++ ) 
@@ -1765,7 +1765,7 @@ namespace casacore {
 		      acc[ival]->startDry(new_field_spw);
 		  for( uInt itime=0; itime<chunk.num(TIME) && ndry; itime++ )
 		    {
-                      if (progmeter.get() != NULL) {
+                      if (progmeter) {
                           progmeter->update(itime);
                       }
 		      // now, call individual VisBuffer iterators
@@ -1799,16 +1799,16 @@ namespace casacore {
 	      sprintf(subtitle,"pass (flag)");
               //cout << "-----------subtitle=" << subtitle << endl;
               
-              std::auto_ptr<ProgressMeter> progmeter(NULL);
+              std::unique_ptr<ProgressMeter> progmeter;
               if (chunk.num(TIME) > progmeter_limit) {
-                  progmeter = std::auto_ptr<ProgressMeter>(new ProgressMeter(1.0,static_cast<Double>(chunk.num(TIME)+0.001),title+"storing flags","","","",True,pm_update_freq));
+                  progmeter.reset(new ProgressMeter(1.0,static_cast<Double>(chunk.num(TIME)+0.001),title+"storing flags","","","",True,pm_update_freq));
               }
 	      for (uInt i = 0; i<acc.size(); i++)
 		if (active_init(i))
 		  acc[i]->startFlag(new_field_spw);
 	      uInt itime=0;
 	      for( vi.origin(); vi.more(); vi++,itime++ ) {
-                  if (progmeter.get() != NULL) {
+                  if (progmeter) {
                       progmeter->update(itime);
                   }
                   

--- a/flagging/Flagging/RFFlagCube.cc
+++ b/flagging/Flagging/RFFlagCube.cc
@@ -1,3 +1,5 @@
+// MV: Is this file unused? I tried to remove usage of auto_ptr throughout the code but in the process noticed that this file is not compiled
+// It is included in the CMakefile at least. Leave it as is for now.
 
 //# RFFlagCube.cc: this defines RFFlagCube
 //# Copyright (C) 2000,2001,2002
@@ -432,12 +434,12 @@ void RFFlagCube::getMSFlags(uInt it)
       in_flags_flushed = false;
   }
   
-  auto_ptr<FlagVector> fl_row(NULL);
+  std::unique_ptr<FlagVector> fl_row;
   FlagVector *flr = NULL;
 
   //  FlagVector fl_row;//(flagrow.column(pos_get_flag));
   if (!kiss) {
-      fl_row = auto_ptr<FlagVector>(new FlagVector(flagrow.column(pos_get_flag)));
+      fl_row.reset(new FlagVector(flagrow.column(pos_get_flag)));
       flr = fl_row.get();
   }
 

--- a/msvis/MSVis/SubMS.cc
+++ b/msvis/MSVis/SubMS.cc
@@ -51,8 +51,6 @@
 #include <casacore/casa/Logging/LogIO.h>
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/OS/HostInfo.h>
-#include <casacore/casa/OS/Memory.h>              // Can be commented out along with
-//                                         // Memory:: calls.
 
 //#ifdef COPYTIMER
 #include <casacore/casa/OS/Timer.h>
@@ -6813,11 +6811,6 @@ Bool SubMS::fillAverMainTable(const Vector<MS::PredefinedColumns>& colNames)
 {    
   LogIO os(LogOrigin("SubMS", "fillAverMainTable()"));
     
-  os << LogIO::DEBUG1 // helpdesk ticket in from Oleg Smirnov (ODU-232630)
-     << "Before fillAntIndexer(): "
-     << Memory::allocatedMemoryInBytes() / (1024.0 * 1024.0) << " MB"
-     << LogIO::POST;
-
   // fill time and timecentroid and antennas
   if(fillAntIndexer(mscIn_p, antIndexer_p) < 1)
     return False;
@@ -7817,10 +7810,6 @@ Bool SubMS::doChannelMods(const Vector<MS::PredefinedColumns>& datacols)
   //ROTiledStManAccessor tacc(mssel_p, cdesc.dataManagerGroup());
   //tacc.showCacheStatistics(cerr);  // A 99.x% hit rate is good.  0% is bad.
 
-  os << LogIO::DEBUG1 // helpdesk ticket in from Oleg Smirnov (ODU-232630)
-     << "Post binning memory: " << Memory::allocatedMemoryInBytes() / (1024.0 * 1024.0) << " MB"
-     << LogIO::POST;
-
   return True;
 }
 
@@ -8029,11 +8018,6 @@ Bool SubMS::doTimeAver(const Vector<MS::PredefinedColumns>& dataColNames)
   if(stateRemapper_p.size() < 1)
     make_map(mscIn_p->stateId(), stateRemapper_p);
 
-  os << LogIO::DEBUG1 // helpdesk ticket from Oleg Smirnov (ODU-232630)
-     << "Before msOut_p.addRow(): "
-     << Memory::allocatedMemoryInBytes() / (1024.0 * 1024.0) << " MB"
-     << LogIO::POST;
-
   Vector<MS::PredefinedColumns> cmplxColLabels;
   const Bool doFloat = sepFloat(dataColNames, cmplxColLabels);
   const uInt nCmplx = cmplxColLabels.nelements();
@@ -8237,10 +8221,6 @@ Bool SubMS::doTimeAver(const Vector<MS::PredefinedColumns>& dataColNames)
   //ROTiledStManAccessor tacc(mssel_p, cdesc.dataManagerGroup());
   //tacc.showCacheStatistics(cerr);  // A 99.x% hit rate is good.  0% is bad.
 
-  os << LogIO::DEBUG1 // helpdesk ticket in from Oleg Smirnov (ODU-232630)
-     << "Post binning memory: " << Memory::allocatedMemoryInBytes() / (1024.0 * 1024.0) << " MB"
-     << LogIO::POST;
-
   if(rowsdone < 1){
     os << LogIO::WARN
        << "No rows were written.  Is all the selected input flagged?"
@@ -8264,11 +8244,6 @@ Bool SubMS::doTimeAverVisIterator(const Vector<MS::PredefinedColumns>& dataColNa
 
   if(stateRemapper_p.size() < 1)
     make_map(mscIn_p->stateId(), stateRemapper_p);
-
-  os << LogIO::DEBUG1 // helpdesk ticket from Oleg Smirnov (ODU-232630)
-     << "Before msOut_p.addRow(): "
-     << Memory::allocatedMemoryInBytes() / (1024.0 * 1024.0) << " MB"
-     << LogIO::POST;
 
   Vector<MS::PredefinedColumns> cmplxColLabels;
   const Bool doFloat = sepFloat(dataColNames, cmplxColLabels);
@@ -8462,10 +8437,6 @@ Bool SubMS::doTimeAverVisIterator(const Vector<MS::PredefinedColumns>& dataColNa
     meter.update(inrowsdone);
   }   // End of for(vi.originChunks(); vi.moreChunks(); vi.nextChunk())
   os << LogIO::NORMAL << "Data binned." << LogIO::POST;
-
-  os << LogIO::DEBUG1 // helpdesk ticket in from Oleg Smirnov (ODU-232630)
-     << "Post binning memory: " << Memory::allocatedMemoryInBytes() / (1024.0 * 1024.0) << " MB"
-     << LogIO::POST;
 
   if(rowsdone < 1){
     os << LogIO::WARN

--- a/msvis/MSVis/UtilJ.h
+++ b/msvis/MSVis/UtilJ.h
@@ -92,7 +92,7 @@ template <typename F, typename S>
 const F & first (const std::pair<F,S> & pair) { return pair.first;}
 
 template <typename F, typename S>
-class FirstFunctor : public std::unary_function<std::pair<F,S>, F>{
+class FirstFunctor : public std::function<F(std::pair<F,S>)>{
 public:
     F & operator() (std::pair<F,S> & p) { return p.first; }
     const F & operator() (const std::pair<F,S> & p) { return p.first; }
@@ -196,7 +196,7 @@ template <typename F, typename S>
 const F & second (const std::pair<F,S> & pair) { return pair.second;}
 
 template <typename F, typename S>
-class SecondFunctor : public std::unary_function<std::pair<F,S>, F>{
+class SecondFunctor : public std::function<S(std::pair<F,S>)>{
 public:
     S & operator() (std::pair<F,S> & p) { return p.second; }
 };
@@ -428,7 +428,7 @@ private:
 
 /*
 
-Example of using composer and unary.  The composed functors have to be derived from std::unary_function
+Example of using composer and unary.  
 
   int f(int x) { return x*x;}
   int g(int x) { return 2 * x;}
@@ -457,7 +457,7 @@ Example of using composer and unary.  The composed functors have to be derived f
 */
 
 template <typename F, typename G>
-class ComposedFunctor : public std::unary_function <typename G::argument_type, typename F::result_type> {
+class ComposedFunctor : public std::function <typename F::result_type (typename G::argument_type)> {
 
 public:
 
@@ -479,7 +479,7 @@ compose (F f, G g)
 }
 
 template <typename D, typename R>
-class UnaryFunctor : public std::unary_function<D,R> {
+class UnaryFunctor : public std::function<R(D)> {
 public:
     typedef R (* F) (D);
 

--- a/msvis/MSVis/test/tVisibilityIteratorAsync.cc
+++ b/msvis/MSVis/test/tVisibilityIteratorAsync.cc
@@ -36,7 +36,6 @@
 #include <casacore/casa/Arrays/ArrayMath.h>
 #include <casacore/casa/BasicSL/Constants.h>
 #include <memory>
-using std::auto_ptr;
 
 #include <casacore/tables/DataMan/ForwardCol.h>
 
@@ -72,7 +71,7 @@ main(int argc, char **argv)
                     ROVisibilityIteratorAsync::prefetchColumns(VIA::Ant1, VIA::Ant2, VIA::Freq, VIA::Time,
 							       VIA::ObservedCube, VIA::Sigma, VIA::Flag, VIA::Uvw,
                                                              -1);
-            auto_ptr<ROVisibilityIterator> syniter (ROVisibilityIteratorAsync::create (synms,prefetchColumns, bi));
+            std::unique_ptr<ROVisibilityIterator> syniter (ROVisibilityIteratorAsync::create (synms,prefetchColumns, bi));
             VisBufferAutoPtr vb (syniter.get());
 
             // set iterator to start of data
@@ -136,7 +135,7 @@ main(int argc, char **argv)
 
             cout << " Now try to iterate in time-intervals of 10s"<<endl;
 
-            auto_ptr <ROVisibilityIterator>
+            std::unique_ptr <ROVisibilityIterator>
             syniter2 (ROVisibilityIteratorAsync::create (synms,prefetchColumns, bi,10.));
 
             VisBufferAutoPtr vb2 (* syniter2);
@@ -163,7 +162,7 @@ main(int argc, char **argv)
             ROVisibilityIteratorAsync::PrefetchColumns prefetchColumns =
                     ROVisibilityIteratorAsync::prefetchColumns(VIA::Time, -1);
 
-            auto_ptr <ROVisibilityIterator>
+            std::unique_ptr <ROVisibilityIterator>
             syniter3 (ROVisibilityIteratorAsync::create(synms,prefetchColumns, bi,10.));
 
             syniter3->setInterval(1000.);

--- a/synthesis/MeasurementEquations/SkyEquation.cc
+++ b/synthesis/MeasurementEquations/SkyEquation.cc
@@ -79,7 +79,6 @@
 #include <casacore/casa/System/ProgressMeter.h>
 
 #include <memory>
-using std::auto_ptr;
 
 namespace casacore { //# NAMESPACE CASACORE - BEGIN
 


### PR DESCRIPTION
Made the code compilable against casacore-3.7.1 and better compliance with the C++17 standard (removed std::unary_function and std::auto_ptr). Also modified cmake file to match the requirements of that in casacore and avoid problems with recent cmake versions. No functional changes.