### PR TITLE
relaxed criterion in consistency checks due to numerical precision

### DIFF
--- a/components/ComponentModels/DiskShape.cc
+++ b/components/ComponentModels/DiskShape.cc
@@ -291,7 +291,7 @@ Bool DiskShape::ok() const {
            << LogIO::POST;
     return False;
   }
-  if (!near(itsHeight, 1.0/(C::pi*itsMajValue*itsMinValue), 2*C::dbl_epsilon)) {
+  if (!near(itsHeight, 1.0/(C::pi*itsMajValue*itsMinValue), 10*C::dbl_epsilon)) {
     LogIO logErr(LogOrigin("DiskCompRep", "ok()"));
     logErr << LogIO::SEVERE << "The disk shape does not have"
 	   << " unit area"

--- a/components/ComponentModels/GaussianShape.cc
+++ b/components/ComponentModels/GaussianShape.cc
@@ -244,14 +244,15 @@ Bool GaussianShape::ok() const {
   // performance reasons. Both function static and file static variables
   // where considered and rejected for this purpose.
   if (!TwoSidedShape::ok()) return False;
-  if (!near(itsShape.flux(), Double(1.0), 2*C::dbl_epsilon)) {
+  if (!near(itsShape.flux(), Double(1.0), 10*C::dbl_epsilon)) {
     LogIO logErr(LogOrigin("GaussianCompRep", "ok()"));
     logErr << LogIO::SEVERE << "The internal Gaussian shape does not have"
 	   << " unit area"
+           << " unit area: " << itsShape.flux() << " difference from 1: "<< itsShape.flux()-1.0
            << LogIO::POST;
     return False;
   }
-  if (!near(itsFT.height(), 1.0, 2*C::dbl_epsilon)) {
+  if (!near(itsFT.height(), 1.0, 10*C::dbl_epsilon)) {
     LogIO logErr(LogOrigin("GaussianCompRep", "ok()"));
     logErr << LogIO::SEVERE << "The cached Fourier Transform of"
 	   << " the internal Gaussian shape does not have"

--- a/components/ComponentModels/LimbDarkenedDiskShape.cc
+++ b/components/ComponentModels/LimbDarkenedDiskShape.cc
@@ -338,7 +338,7 @@ Bool LimbDarkenedDiskShape::ok() const {
            << LogIO::POST;
     return False;
   }
-  if (!near(itsHeight, 1.0/(C::pi*itsMajValue*itsMinValue), 2*C::dbl_epsilon)) {
+  if (!near(itsHeight, 1.0/(C::pi*itsMajValue*itsMinValue), 10*C::dbl_epsilon)) {
     LogIO logErr(LogOrigin("DiskCompRep", "ok()"));
     logErr << LogIO::SEVERE << "The disk shape does not have"
            << " unit area"

--- a/components/ComponentModels/TwoSidedShape.cc
+++ b/components/ComponentModels/TwoSidedShape.cc
@@ -244,7 +244,7 @@ Bool TwoSidedShape::fromRecord(String& errorMessage,
 //   // near function was added here and in the setMinorAxis function to fix
 //   // defect AOCso00071
   if (majorAxisInRad < minorAxisInRad && 
-      !near(minorAxisInRad, minorAxisInRad, 2*C::dbl_epsilon)) {
+      !near(minorAxisInRad, minorAxisInRad, 10*C::dbl_epsilon)) {
     errorMessage += "The major axis cannot be smaller than the minor axis\n";
     return False;
   }


### PR DESCRIPTION
Relaxed criterion in various consistency cross-checks to avoid failures due to numerical precision. Such failures were found to occur in ASKAP processing (issue AXA-3435).