### PR TITLE
Fixed a problem where AlwaysAssert macro does not like std::unique_pt…

### DIFF
--- a/synthesis/Images/ADIOSImage.tcc
+++ b/synthesis/Images/ADIOSImage.tcc
@@ -285,7 +285,8 @@ void ADIOSImage<T>::restoreAll (const casacore::TableRecord& rec)
   // MV: I am not sure whether we're supposed to take the ownership of the returned raw pointer, but the original code 
   // written with raw pointers did the equivalent thing
   std::unique_ptr<casacore::CoordinateSystem> restoredCoords(casacore::CoordinateSystem::restore(rec, "coords"));
-  AlwaysAssert(restoredCoords, casacore::AipsError);
+  const bool notNull = static_cast<bool>(restoredCoords);
+  AlwaysAssert(notNull, casacore::AipsError);
   this->setCoordsMember(*restoredCoords);
   // Restore the image info.
   restoreImageInfo (rec);


### PR DESCRIPTION
The compiler error message generated for this problem is shown below:

casacore/casa/Utilities/Assert.h:156:36: error: no matching function for call to ‘casacore::assert_<casacore::AipsError>::assert_(std::unique_ptr<casacore::CoordinateSystem>&, const char [35], const char [107], casacore::Int)’
  156 |     {casacore::assert_<exception > dummy_(expr, "Failed AlwaysAssert " #expr,__FILE__,(casacore::Int)__LINE__); dummy_.null(); }

casarest/synthesis/Images//ADIOSImage.tcc:289:3: note: in expansion of macro ‘AlwaysAssert’
  289 |   AlwaysAssert(restoredCoords, casacore::AipsError);